### PR TITLE
Use .atMost() in stack layouts to enable alignment

### DIFF
--- a/Sources/Whisker/Core/ViewBuilder.swift
+++ b/Sources/Whisker/Core/ViewBuilder.swift
@@ -74,7 +74,11 @@ final class NodeViewBuilder {
         }
 
         node.layout = { proposal, _ in
-            let width = proposal.width.resolve(with: 1)
+            let width: Int
+            switch proposal.width {
+            case .atMost(let v), .exactly(let v): width = v
+            case .unconstrained: width = 1
+            }
             return (Size(width: width, height: 1), [])
         }
     }

--- a/Sources/Whisker/Layout/Layout.swift
+++ b/Sources/Whisker/Layout/Layout.swift
@@ -74,7 +74,7 @@ public struct VStackLayout: Layout {
         for child in children {
             let childSize = child.sizeThatFits(
                 ProposedSize(
-                    width: .exactly(bounds.width),
+                    width: .atMost(bounds.width),
                     height: .unconstrained
                 ))
 
@@ -145,7 +145,7 @@ public struct HStackLayout: Layout {
             let childSize = child.sizeThatFits(
                 ProposedSize(
                     width: .atMost(remainingWidth),
-                    height: .exactly(bounds.height)
+                    height: .atMost(bounds.height)
                 ))
 
             let y: Int
@@ -196,7 +196,11 @@ public struct ZStackLayout: Layout {
 
     public func placeChildren(in bounds: Rect, children: [LayoutChild]) {
         for child in children {
-            let childSize = child.sizeThatFits(ProposedSize(bounds.size))
+            let childSize = child.sizeThatFits(
+                ProposedSize(
+                    width: .atMost(bounds.width),
+                    height: .atMost(bounds.height)
+                ))
 
             let x: Int
             switch alignment.horizontal {


### PR DESCRIPTION
## Summary
Replace `.exactly()` with `.atMost()` when proposing sizes to child views in stack layouts (VStack, HStack, ZStack). This change allows child views to properly align and size themselves based on available space rather than being forced to exact bounds.

Also update ViewBuilder to explicitly handle different proposal width types instead of using the generic resolve method.

## Changes
- VStackLayout: Use `.atMost(bounds.width)` instead of `.exactly()`
- HStackLayout: Use `.atMost(bounds.height)` instead of `.exactly()`
- ZStackLayout: Use explicit `.atMost()` proposals instead of passing size directly
- ViewBuilder: Handle ProposalSize width cases explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved divider layout behavior to properly respect width constraints from parent containers instead of using fixed sizing.
* Enhanced stacked layout calculations to use more flexible sizing constraints when positioning child elements, resulting in better layout accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->