### PR TITLE
feat: add .task modifier and ActivityIndicator

### DIFF
--- a/Sources/Examples/main.swift
+++ b/Sources/Examples/main.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Whisker
 
 // ============================================================================
@@ -25,8 +26,39 @@ struct FormView: View {
     @State var planIndex = 0
     @State var message = ""
     @State var messageColor: Color = .white
+    @State var phase: Int = 0
+    @State var submittedAt: Double = 0
+
+    /// Check elapsed time and advance through submission phases.
+    ///
+    /// This is the key to time-based transitions in a declarative framework:
+    /// instead of callbacks ("after 2s, do X"), we ask "given the current
+    /// time, what phase should we be in?" every time the view rebuilds.
+    ///
+    /// - Phase 1 rebuilds continuously (~60fps) because ActivityIndicator
+    ///   keeps the animation tick alive.
+    /// - Phases 2 and 3 have no spinner, so we use scheduleUpdate(after:)
+    ///   as an alarm clock to trigger the next rebuild.
+    private func advancePhaseIfNeeded() {
+        guard submittedAt > 0 else { return }
+        let elapsed = Date().timeIntervalSinceReferenceDate - submittedAt
+
+        if phase == 1 && elapsed >= 2.0 {
+            phase = 2
+            Application.shared?.scheduleUpdate(after: 1.0)
+        } else if phase == 2 && elapsed >= 3.0 {
+            phase = 3
+            Application.shared?.scheduleUpdate(after: 1.0)
+        } else if phase == 3 && elapsed >= 4.0 {
+            Application.shared?.quit()
+        }
+    }
 
     var body: some View {
+        // Advance phase based on elapsed time before rendering.
+        // This call has side effects (@State mutations) but returns Void,
+        // so we use a let binding to keep the result builder happy.
+        let _ = advancePhaseIfNeeded()
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 0) {
                 Text("? ").foregroundColor(.yellow)
@@ -63,30 +95,57 @@ struct FormView: View {
                 )
                 .foregroundColor(.brightCyan)
             }
-            HStack(spacing: 0) {
-                Text("  ")
-                Button("Submit") {
-                    if name.isEmpty {
-                        message = "  ✗ Name is required"
-                        messageColor = .red
-                    } else if email.isEmpty || !email.contains("@") {
-                        message = "  ✗ Valid email is required"
-                        messageColor = .red
-                    } else if password.count < 4 {
-                        message = "  ✗ Password must be at least 4 characters"
-                        messageColor = .red
-                    } else if password != confirmPassword {
-                        message = "  ✗ Passwords do not match"
-                        messageColor = .red
-                    } else {
-                        let planName = plans.indices.contains(planIndex)
-                            ? plans[planIndex] : plans[0]
-                        message = "  ✓ Welcome, \(name)! (\(planName))"
-                        messageColor = .green
-                        Application.shared?.quit()
+            if phase == 0 {
+                HStack(spacing: 0) {
+                    Text("  ")
+                    Button("Submit") {
+                        if name.isEmpty {
+                            message = "  ✗ Name is required"
+                            messageColor = .red
+                        } else if email.isEmpty || !email.contains("@") {
+                            message = "  ✗ Valid email is required"
+                            messageColor = .red
+                        } else if password.count < 4 {
+                            message = "  ✗ Password must be at least 4 characters"
+                            messageColor = .red
+                        } else if password != confirmPassword {
+                            message = "  ✗ Passwords do not match"
+                            messageColor = .red
+                        } else {
+                            phase = 1
+                            submittedAt = Date().timeIntervalSinceReferenceDate
+                        }
                     }
+                    Text(message).foregroundColor(messageColor)
                 }
-                Text(message).foregroundColor(messageColor)
+            } else if phase == 1 {
+                // Phase 1: Loading spinner (lasts 2 seconds)
+                //
+                // The ActivityIndicator keeps the run loop ticking at ~60fps,
+                // so this body runs every frame. Each frame we check: has 2s
+                // passed? If not, do nothing — just keep showing the spinner.
+                // If yes, advance to phase 2 and schedule a wake-up for 1s
+                // later (since there will be no spinner to keep ticks alive).
+                HStack(spacing: 0) {
+                    Text("  ")
+                    ActivityIndicator().foregroundColor(.cyan)
+                    Text(" Signing up...").foregroundColor(.cyan)
+                }
+            } else if phase == 2 {
+                // Phase 2: Success checkmark (lasts 1 second)
+                //
+                // We got here because scheduleUpdate(after:) woke us up.
+                // Show the checkmark, and schedule another wake-up for the
+                // final phase.
+                HStack(spacing: 0) {
+                    Text("  ✓ Signed up!").foregroundColor(.green)
+                }
+            } else {
+                // Phase 3: Full welcome message (lasts 1 second, then quit)
+                HStack(spacing: 0) {
+                    Text("  ✓ Welcome, \(name)! (\(plans.indices.contains(planIndex) ? plans[planIndex] : plans[0]))")
+                        .foregroundColor(.green)
+                }
             }
         }
     }

--- a/Sources/Examples/main.swift
+++ b/Sources/Examples/main.swift
@@ -27,38 +27,8 @@ struct FormView: View {
     @State var message = ""
     @State var messageColor: Color = .white
     @State var phase: Int = 0
-    @State var submittedAt: Double = 0
-
-    /// Check elapsed time and advance through submission phases.
-    ///
-    /// This is the key to time-based transitions in a declarative framework:
-    /// instead of callbacks ("after 2s, do X"), we ask "given the current
-    /// time, what phase should we be in?" every time the view rebuilds.
-    ///
-    /// - Phase 1 rebuilds continuously (~60fps) because ActivityIndicator
-    ///   keeps the animation tick alive.
-    /// - Phases 2 and 3 have no spinner, so we use scheduleUpdate(after:)
-    ///   as an alarm clock to trigger the next rebuild.
-    private func advancePhaseIfNeeded() {
-        guard submittedAt > 0 else { return }
-        let elapsed = Date().timeIntervalSinceReferenceDate - submittedAt
-
-        if phase == 1 && elapsed >= 2.0 {
-            phase = 2
-            Application.shared?.scheduleUpdate(after: 1.0)
-        } else if phase == 2 && elapsed >= 3.0 {
-            phase = 3
-            Application.shared?.scheduleUpdate(after: 1.0)
-        } else if phase == 3 && elapsed >= 4.0 {
-            Application.shared?.quit()
-        }
-    }
 
     var body: some View {
-        // Advance phase based on elapsed time before rendering.
-        // This call has side effects (@State mutations) but returns Void,
-        // so we use a let binding to keep the result builder happy.
-        let _ = advancePhaseIfNeeded()
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 0) {
                 Text("? ").foregroundColor(.yellow)
@@ -113,38 +83,36 @@ struct FormView: View {
                             messageColor = .red
                         } else {
                             phase = 1
-                            submittedAt = Date().timeIntervalSinceReferenceDate
                         }
                     }
                     Text(message).foregroundColor(messageColor)
                 }
             } else if phase == 1 {
-                // Phase 1: Loading spinner (lasts 2 seconds)
-                //
-                // The ActivityIndicator keeps the run loop ticking at ~60fps,
-                // so this body runs every frame. Each frame we check: has 2s
-                // passed? If not, do nothing — just keep showing the spinner.
-                // If yes, advance to phase 2 and schedule a wake-up for 1s
-                // later (since there will be no spinner to keep ticks alive).
                 HStack(spacing: 0) {
                     Text("  ")
                     ActivityIndicator().foregroundColor(.cyan)
                     Text(" Signing up...").foregroundColor(.cyan)
                 }
+                .task {
+                    try? await Task.sleep(for: .seconds(2))
+                    phase = 2
+                }
             } else if phase == 2 {
-                // Phase 2: Success checkmark (lasts 1 second)
-                //
-                // We got here because scheduleUpdate(after:) woke us up.
-                // Show the checkmark, and schedule another wake-up for the
-                // final phase.
                 HStack(spacing: 0) {
                     Text("  ✓ Signed up!").foregroundColor(.green)
                 }
+                .task {
+                    try? await Task.sleep(for: .seconds(1))
+                    phase = 3
+                }
             } else {
-                // Phase 3: Full welcome message (lasts 1 second, then quit)
                 HStack(spacing: 0) {
                     Text("  ✓ Welcome, \(name)! (\(plans.indices.contains(planIndex) ? plans[planIndex] : plans[0]))")
                         .foregroundColor(.green)
+                }
+                .task {
+                    try? await Task.sleep(for: .seconds(1))
+                    Application.shared?.quit()
                 }
             }
         }

--- a/Sources/Whisker/Core/Application.swift
+++ b/Sources/Whisker/Core/Application.swift
@@ -17,6 +17,8 @@ public final class Application {
     var focusedIndex: Int = 0
     var updateScheduled = false
     var isRunning = false
+    /// Number of animated views (e.g. `ActivityIndicator`) in the current tree.
+    /// When non-zero, the run loop keeps scheduling redraws.
     var animationTickCount = 0
     let rootViewBuilder: () -> any View
 
@@ -59,6 +61,7 @@ public final class Application {
         updateScheduled = true
     }
 
+    /// Stop the application and cancel any in-flight `.task` work.
     public func quit() {
         isRunning = false
         rootNode?.cancelTasksRecursively()

--- a/Sources/Whisker/Core/Application.swift
+++ b/Sources/Whisker/Core/Application.swift
@@ -17,6 +17,8 @@ public final class Application {
     var focusedIndex: Int = 0
     var updateScheduled = false
     var isRunning = false
+    var animationTickCount = 0
+    private var nextScheduledUpdate: Double = 0
     let rootViewBuilder: () -> any View
 
     private let viewBuilder = NodeViewBuilder()
@@ -54,6 +56,15 @@ public final class Application {
         updateScheduled = true
     }
 
+    /// Schedule an update to occur after a delay (in seconds).
+    /// If multiple delayed updates are scheduled, the earliest one wins.
+    public func scheduleUpdate(after delay: TimeInterval) {
+        let target = Date().timeIntervalSinceReferenceDate + delay
+        if nextScheduledUpdate == 0 || target < nextScheduledUpdate {
+            nextScheduledUpdate = target
+        }
+    }
+
     public func quit() {
         isRunning = false
     }
@@ -68,6 +79,19 @@ public final class Application {
                 updateScheduled = false
                 rebuild()
                 render()
+            }
+
+            // Keep updating while animated views are present
+            if animationTickCount > 0 {
+                updateScheduled = true
+            }
+
+            // Fire delayed updates when their time arrives
+            if nextScheduledUpdate > 0
+                && Date().timeIntervalSinceReferenceDate >= nextScheduledUpdate
+            {
+                nextScheduledUpdate = 0
+                updateScheduled = true
             }
 
             // Small sleep to avoid busy-waiting
@@ -136,6 +160,7 @@ public final class Application {
     }
 
     private func rebuild() {
+        animationTickCount = 0
         let view = rootViewBuilder()
         let oldRoot = rootNode
         rootNode = viewBuilder.buildNode(from: view, existing: oldRoot)

--- a/Sources/Whisker/Core/Application.swift
+++ b/Sources/Whisker/Core/Application.swift
@@ -18,8 +18,11 @@ public final class Application {
     var updateScheduled = false
     var isRunning = false
     var animationTickCount = 0
-    private var nextScheduledUpdate: Double = 0
     let rootViewBuilder: () -> any View
+
+    /// Lock for synchronizing @State mutations from async contexts (e.g. .task closures)
+    /// against the single-threaded rebuild pass. Uncontended in the common synchronous case.
+    let stateLock = NSLock()
 
     private let viewBuilder = NodeViewBuilder()
     private let inlineRenderer = InlineRenderer()
@@ -56,17 +59,9 @@ public final class Application {
         updateScheduled = true
     }
 
-    /// Schedule an update to occur after a delay (in seconds).
-    /// If multiple delayed updates are scheduled, the earliest one wins.
-    public func scheduleUpdate(after delay: TimeInterval) {
-        let target = Date().timeIntervalSinceReferenceDate + delay
-        if nextScheduledUpdate == 0 || target < nextScheduledUpdate {
-            nextScheduledUpdate = target
-        }
-    }
-
     public func quit() {
         isRunning = false
+        rootNode?.cancelTasksRecursively()
     }
 
     private func runLoop() {
@@ -83,14 +78,6 @@ public final class Application {
 
             // Keep updating while animated views are present
             if animationTickCount > 0 {
-                updateScheduled = true
-            }
-
-            // Fire delayed updates when their time arrives
-            if nextScheduledUpdate > 0
-                && Date().timeIntervalSinceReferenceDate >= nextScheduledUpdate
-            {
-                nextScheduledUpdate = 0
                 updateScheduled = true
             }
 

--- a/Sources/Whisker/Core/Node.swift
+++ b/Sources/Whisker/Core/Node.swift
@@ -8,6 +8,7 @@ import Foundation
 public final class PersistentStateStorage: @unchecked Sendable {
     var values: [String: Any] = [:]
 
+    /// Read or write a keyed value in persistent node state.
     subscript(key: String) -> Any? {
         get { values[key] }
         set { values[key] = newValue }

--- a/Sources/Whisker/Core/Node.swift
+++ b/Sources/Whisker/Core/Node.swift
@@ -1,11 +1,25 @@
 import Foundation
 
+/// Reference-type wrapper for persistent state so that @State property wrappers
+/// can hold a strong reference to the storage that survives node reconciliation.
+/// When a new node is reconciled from an old node, both share the same storage
+/// object, so async .task closures that captured the old node's storage still
+/// write to the correct (shared) location.
+public final class PersistentStateStorage: @unchecked Sendable {
+    var values: [String: Any] = [:]
+
+    subscript(key: String) -> Any? {
+        get { values[key] }
+        set { values[key] = newValue }
+    }
+}
+
 public final class Node {
     weak var parent: Node?
     var children: [Node] = []
     var viewType: Any.Type
     var stateStorage: [String: Any] = [:]
-    var persistentState: [String: Any] = [:]
+    var persistentState = PersistentStateStorage()
     var conditionalBranch: Bool?
     var environment: EnvironmentValues = EnvironmentValues()
     var frame: Rect = .zero
@@ -15,8 +29,28 @@ public final class Node {
     var render: ((Rect, inout RenderBuffer) -> Void)?
     var layout: ((ProposedSize, [Node]) -> (Size, [(Node, Rect)]))?
 
+    /// Active async task spawned by a .task modifier. Stored as Any to avoid
+    /// generic constraints on Node — cast to Task<Void, Never> for cancellation.
+    var activeTask: Any?
+
     init(viewType: Any.Type) {
         self.viewType = viewType
+    }
+
+    /// Cancel any active async task on this node
+    func cancelTask() {
+        if let task = activeTask as? Task<Void, Never> {
+            task.cancel()
+        }
+        activeTask = nil
+    }
+
+    /// Cancel all active async tasks in this subtree
+    func cancelTasksRecursively() {
+        cancelTask()
+        for child in children {
+            child.cancelTasksRecursively()
+        }
     }
 
     func addChild(_ child: Node) {

--- a/Sources/Whisker/Core/TaskModifier.swift
+++ b/Sources/Whisker/Core/TaskModifier.swift
@@ -6,9 +6,12 @@ import Foundation
 /// Pairs the runtime type (via `ObjectIdentifier`) with the erased value (`AnyHashable`)
 /// so that e.g. `Int(1)` and `String("1")` are never considered equal.
 struct TaskIdentity: Equatable {
+    /// Runtime type of the identity value, used to distinguish e.g. `Int(1)` from `String("1")`.
     let typeID: ObjectIdentifier
+    /// Erased hashable identity value compared alongside `typeID`.
     let value: AnyHashable
 
+    /// Create a task identity from a hashable value and its runtime type.
     init<H: Hashable>(_ id: H) {
         self.typeID = ObjectIdentifier(type(of: id))
         self.value = AnyHashable(id)

--- a/Sources/Whisker/Core/TaskModifier.swift
+++ b/Sources/Whisker/Core/TaskModifier.swift
@@ -1,12 +1,31 @@
 import Foundation
 
+// MARK: - Task Identity
+
+/// Type-safe identity for `.task(id:)` that avoids string interpolation collisions.
+/// Pairs the runtime type (via `ObjectIdentifier`) with the erased value (`AnyHashable`)
+/// so that e.g. `Int(1)` and `String("1")` are never considered equal.
+struct TaskIdentity: Equatable {
+    let typeID: ObjectIdentifier
+    let value: AnyHashable
+
+    init<H: Hashable>(_ id: H) {
+        self.typeID = ObjectIdentifier(type(of: id))
+        self.value = AnyHashable(id)
+    }
+
+    /// Sentinel identity used by the no-argument `.task {}` overload.
+    private enum DefaultSentinel: Hashable { case `default` }
+    static let `default` = TaskIdentity(DefaultSentinel.default)
+}
+
 // MARK: - Task Modifier
 
 /// Internal protocol so NodeViewBuilder can detect any TaskModifier regardless of Content type
 protocol _TaskModifierProtocol {
     var _content: any View { get }
     var _taskBody: @Sendable () async -> Void { get }
-    var _taskID: String { get }
+    var _taskID: TaskIdentity { get }
 }
 
 /// A modifier that spawns an async task when its view enters the tree.
@@ -17,11 +36,11 @@ struct TaskModifier<Content: View>: View, _TaskModifierProtocol {
 
     let content: Content
     let taskBody: @Sendable () async -> Void
-    let taskID: String
+    let taskID: TaskIdentity
 
     var _content: any View { content }
     var _taskBody: @Sendable () async -> Void { taskBody }
-    var _taskID: String { taskID }
+    var _taskID: TaskIdentity { taskID }
 
     public var body: Never {
         fatalError("TaskModifier has no body")
@@ -38,7 +57,7 @@ public extension View {
     ///             phase = 2
     ///         }
     func task(_ action: @escaping @Sendable () async -> Void) -> some View {
-        TaskModifier(content: self, taskBody: action, taskID: "default")
+        TaskModifier(content: self, taskBody: action, taskID: .default)
     }
 
     /// Attach an asynchronous task that restarts when `id` changes.
@@ -49,6 +68,6 @@ public extension View {
     ///             n += 1
     ///         }
     func task(id: some Hashable, _ action: @escaping @Sendable () async -> Void) -> some View {
-        TaskModifier(content: self, taskBody: action, taskID: "\(type(of: id)):\(id)")
+        TaskModifier(content: self, taskBody: action, taskID: TaskIdentity(id))
     }
 }

--- a/Sources/Whisker/Core/TaskModifier.swift
+++ b/Sources/Whisker/Core/TaskModifier.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// MARK: - Task Modifier
+
+/// Internal protocol so NodeViewBuilder can detect any TaskModifier regardless of Content type
+protocol _TaskModifierProtocol {
+    var _content: any View { get }
+    var _taskBody: @Sendable () async -> Void { get }
+    var _taskID: String { get }
+}
+
+/// A modifier that spawns an async task when its view enters the tree.
+/// The task is automatically cancelled when the view leaves the tree
+/// (e.g. when a conditional branch switches).
+struct TaskModifier<Content: View>: View, _TaskModifierProtocol {
+    public typealias Body = Never
+
+    let content: Content
+    let taskBody: @Sendable () async -> Void
+    let taskID: String
+
+    var _content: any View { content }
+    var _taskBody: @Sendable () async -> Void { taskBody }
+    var _taskID: String { taskID }
+
+    public var body: Never {
+        fatalError("TaskModifier has no body")
+    }
+}
+
+public extension View {
+    /// Attach an asynchronous task that runs when this view appears.
+    /// The task is cancelled when the view is removed from the tree.
+    ///
+    ///     Text("Loading...")
+    ///         .task {
+    ///             try? await Task.sleep(for: .seconds(2))
+    ///             phase = 2
+    ///         }
+    func task(_ action: @escaping @Sendable () async -> Void) -> some View {
+        TaskModifier(content: self, taskBody: action, taskID: "default")
+    }
+
+    /// Attach an asynchronous task that restarts when `id` changes.
+    ///
+    ///     Text("Count: \(n)")
+    ///         .task(id: n) {
+    ///             try? await Task.sleep(for: .seconds(1))
+    ///             n += 1
+    ///         }
+    func task(id: some Hashable, _ action: @escaping @Sendable () async -> Void) -> some View {
+        TaskModifier(content: self, taskBody: action, taskID: "\(id)")
+    }
+}

--- a/Sources/Whisker/Core/TaskModifier.swift
+++ b/Sources/Whisker/Core/TaskModifier.swift
@@ -49,6 +49,6 @@ public extension View {
     ///             n += 1
     ///         }
     func task(id: some Hashable, _ action: @escaping @Sendable () async -> Void) -> some View {
-        TaskModifier(content: self, taskBody: action, taskID: "\(id)")
+        TaskModifier(content: self, taskBody: action, taskID: "\(type(of: id)):\(id)")
     }
 }

--- a/Sources/Whisker/Core/ViewBuilder.swift
+++ b/Sources/Whisker/Core/ViewBuilder.swift
@@ -189,7 +189,7 @@ final class NodeViewBuilder {
         let taskIDKey = "_task_id"
         let taskStartedKey = "_task_started"
         let currentID = modifier._taskID
-        let previousID = existing?.persistentState[taskIDKey] as? String
+        let previousID = existing?.persistentState[taskIDKey] as? TaskIdentity
         let wasStarted = existing?.persistentState[taskStartedKey] as? Bool ?? false
 
         if previousID == currentID && wasStarted {

--- a/Sources/Whisker/Core/ViewBuilder.swift
+++ b/Sources/Whisker/Core/ViewBuilder.swift
@@ -35,6 +35,9 @@ final class NodeViewBuilder {
         } else if view is Divider {
             buildDividerNode(node)
             return true
+        } else if let indicator = view as? ActivityIndicator {
+            buildActivityIndicatorNode(node, indicator: indicator)
+            return true
         }
         return false
     }
@@ -85,6 +88,24 @@ final class NodeViewBuilder {
             case .unconstrained: width = 1
             }
             return (Size(width: width, height: 1), [])
+        }
+    }
+
+    private func buildActivityIndicatorNode(_ node: Node, indicator: ActivityIndicator) {
+        Application.shared?.animationTickCount += 1
+
+        node.render = { [weak node] frame, buffer in
+            guard let node = node else { return }
+            let style = Style().resolved(with: node.environment)
+            let frameIndex = indicator.currentFrameIndex()
+            let char = ActivityIndicator.frames[frameIndex]
+            buffer.draw(char, at: Position(x: frame.x, y: frame.y), style: style)
+        }
+
+        node.layout = { proposal, _ in
+            let width = proposal.width.resolve(with: 1)
+            let height = proposal.height.resolve(with: 1)
+            return (Size(width: width, height: height), [])
         }
     }
 

--- a/Sources/Whisker/Core/ViewBuilder.swift
+++ b/Sources/Whisker/Core/ViewBuilder.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 final class NodeViewBuilder {
     func buildNode(from view: any View, existing: Node? = nil) -> Node {
         let node = Node(viewType: type(of: view))
@@ -10,7 +12,15 @@ final class NodeViewBuilder {
         // Reconcile: copy persistent state from old node if types match
         if let existing = existing, existing.viewType == node.viewType {
             node.persistentState = existing.persistentState
+        } else if let existing = existing {
+            // View type changed — cancel any async tasks in the old subtree
+            existing.cancelTasksRecursively()
         }
+
+        // Eagerly resolve all @State properties so their Boxes capture the
+        // current node's PersistentStateStorage. This is necessary for .task
+        // closures that capture @State but don't read it during the build pass.
+        resolveStateProperties(of: view)
 
         if !buildPrimitiveNode(node, from: view) &&
             !buildContainerNode(node, from: view, existing: existing) &&
@@ -115,6 +125,9 @@ final class NodeViewBuilder {
         if let modifier = view as? any _EnvironmentModifierProtocol {
             buildEnvironmentNode(node, modifier: modifier, existing: existing)
             return true
+        } else if let taskMod = view as? any _TaskModifierProtocol {
+            buildTaskModifierNode(node, modifier: taskMod, existing: existing)
+            return true
         } else if let vstack = view as? any _VStackProtocol {
             buildVStackNode(node, content: vstack._content, alignment: vstack._alignment, spacing: vstack._spacing, existing: existing)
             return true
@@ -152,6 +165,48 @@ final class NodeViewBuilder {
             let childLayout = LayoutChild(node: firstChild)
             return (childLayout.sizeThatFits(proposal), [])
         }
+    }
+
+    private func buildTaskModifierNode(_ node: Node, modifier: any _TaskModifierProtocol, existing: Node?) {
+        // Build child content (pass through, same as EnvironmentModifier)
+        let existingChild = existing?.children.first
+        let childNode = buildNode(from: modifier._content, existing: existingChild)
+        node.addChild(childNode)
+
+        // Passthrough layout — the modifier is invisible, child determines size
+        node.layout = { [weak node] proposal, _ in
+            guard let node = node, let firstChild = node.children.first else {
+                return (.zero, [])
+            }
+            let childLayout = LayoutChild(node: firstChild)
+            return (childLayout.sizeThatFits(proposal), [])
+        }
+
+        // Task lifecycle: start a new task if this is a fresh appearance,
+        // or if the task ID changed (for .task(id:) variant).
+        // Use two keys: one for the task ID, one to track whether the task
+        // has already been started (so we don't re-spawn after it completes).
+        let taskIDKey = "_task_id"
+        let taskStartedKey = "_task_started"
+        let currentID = modifier._taskID
+        let previousID = existing?.persistentState[taskIDKey] as? String
+        let wasStarted = existing?.persistentState[taskStartedKey] as? Bool ?? false
+
+        if previousID == currentID && wasStarted {
+            // Same ID, task already started — carry forward (may still be running or finished)
+            node.activeTask = existing?.activeTask
+        } else {
+            // New appearance or ID changed — cancel old task if any, start new one
+            existing?.cancelTask()
+
+            let taskBody = modifier._taskBody
+            node.activeTask = Task {
+                await taskBody()
+            }
+        }
+
+        node.persistentState[taskIDKey] = currentID
+        node.persistentState[taskStartedKey] = true
     }
 
     func applyLayout(_ node: Node, engine: any Layout) {
@@ -223,6 +278,8 @@ final class NodeViewBuilder {
            let oldChild = existing.children.first {
             existingChild = oldChild
         } else {
+            // Branch changed — cancel any async tasks in the old subtree
+            existing?.children.first?.cancelTasksRecursively()
             existingChild = nil
         }
 
@@ -265,6 +322,22 @@ final class NodeViewBuilder {
             }
             let childLayout = LayoutChild(node: firstChild)
             return (childLayout.sizeThatFits(proposal), [])
+        }
+    }
+
+    // MARK: - State Resolution
+
+    /// Walk the view struct using Mirror and call _resolveStorage() on every
+    /// @State (DynamicProperty) found. This ensures each @State's Box captures
+    /// the current node's PersistentStateStorage while NodeContext.current is set.
+    /// Without this, @State properties that are only used inside .task closures
+    /// (and never read during body evaluation) would fail to resolve.
+    private func resolveStateProperties(of view: any View) {
+        let mirror = Mirror(reflecting: view)
+        for child in mirror.children {
+            if let prop = child.value as? any DynamicProperty {
+                prop._resolveStorage()
+            }
         }
     }
 

--- a/Sources/Whisker/Core/ViewBuilder.swift
+++ b/Sources/Whisker/Core/ViewBuilder.swift
@@ -101,6 +101,7 @@ final class NodeViewBuilder {
         }
     }
 
+    /// Build a 1×1 animated spinner node and register it with the application run loop.
     private func buildActivityIndicatorNode(_ node: Node, indicator: ActivityIndicator) {
         Application.shared?.animationTickCount += 1
 
@@ -168,6 +169,7 @@ final class NodeViewBuilder {
         }
     }
 
+    /// Build a passthrough node that spawns or preserves an async `.task` for its content.
     private func buildTaskModifierNode(_ node: Node, modifier: any _TaskModifierProtocol, existing: Node?) {
         // Build child content (pass through, same as EnvironmentModifier)
         let existingChild = existing?.children.first
@@ -349,6 +351,7 @@ final class NodeViewBuilder {
 
     // MARK: - Helpers
 
+    /// Cancel async work in reconciled-out container children that are no longer in the tree.
     private func cancelDroppedChildren(_ existingChildren: [Node], keeping count: Int) {
         for dropped in existingChildren.dropFirst(count) {
             dropped.cancelTasksRecursively()

--- a/Sources/Whisker/Core/ViewBuilder.swift
+++ b/Sources/Whisker/Core/ViewBuilder.swift
@@ -106,6 +106,7 @@ final class NodeViewBuilder {
 
         node.render = { [weak node] frame, buffer in
             guard let node = node else { return }
+            guard frame.width > 0, frame.height > 0 else { return }
             let style = Style().resolved(with: node.environment)
             let frameIndex = indicator.currentFrameIndex()
             let char = ActivityIndicator.frames[frameIndex]
@@ -230,6 +231,7 @@ final class NodeViewBuilder {
             let existingChild = index < existingChildren.count ? existingChildren[index] : nil
             node.addChild(buildNode(from: childView, existing: existingChild))
         }
+        cancelDroppedChildren(existingChildren, keeping: children.count)
         applyLayout(node, engine: VStackLayout(alignment: alignment, spacing: spacing))
     }
 
@@ -240,6 +242,7 @@ final class NodeViewBuilder {
             let existingChild = index < existingChildren.count ? existingChildren[index] : nil
             node.addChild(buildNode(from: childView, existing: existingChild))
         }
+        cancelDroppedChildren(existingChildren, keeping: children.count)
         applyLayout(node, engine: HStackLayout(alignment: alignment, spacing: spacing))
     }
 
@@ -250,6 +253,7 @@ final class NodeViewBuilder {
             let existingChild = index < existingChildren.count ? existingChildren[index] : nil
             node.addChild(buildNode(from: childView, existing: existingChild))
         }
+        cancelDroppedChildren(existingChildren, keeping: children.count)
         applyLayout(node, engine: ZStackLayout(alignment: alignment))
     }
 
@@ -264,6 +268,7 @@ final class NodeViewBuilder {
             let existingChild = index < existingChildren.count ? existingChildren[index] : nil
             node.addChild(buildNode(from: childView, existing: existingChild))
         }
+        cancelDroppedChildren(existingChildren, keeping: children.count)
         applyLayout(node, engine: VStackLayout(alignment: .leading, spacing: 0))
     }
 
@@ -301,6 +306,7 @@ final class NodeViewBuilder {
             let existingChild = index < existingChildren.count ? existingChildren[index] : nil
             node.addChild(buildNode(from: childView, existing: existingChild))
         }
+        cancelDroppedChildren(existingChildren, keeping: children.count)
         applyLayout(node, engine: VStackLayout(alignment: .leading, spacing: 0))
     }
 
@@ -342,6 +348,12 @@ final class NodeViewBuilder {
     }
 
     // MARK: - Helpers
+
+    private func cancelDroppedChildren(_ existingChildren: [Node], keeping count: Int) {
+        for dropped in existingChildren.dropFirst(count) {
+            dropped.cancelTasksRecursively()
+        }
+    }
 
     func extractViews(from value: Any) -> [any View] {
         if let tupleView = value as? any _TupleViewProtocol {

--- a/Sources/Whisker/State/State.swift
+++ b/Sources/Whisker/State/State.swift
@@ -9,11 +9,26 @@ public enum NodeContext {
 }
 
 /// Property wrapper for local view state.
-/// Uses a class-based Box to capture the node reference on first access,
-/// enabling wrappedValue and projectedValue to work in closures outside the build pass.
+/// Uses a class-based Box to capture a strong reference to the node's
+/// PersistentStateStorage on first access. Because PersistentStateStorage is
+/// a reference type shared between old and new nodes during reconciliation,
+/// async .task closures that captured @State can still write to the correct
+/// storage even after the node tree has been rebuilt.
+///
+/// Thread safety: State mutations are protected by Application.stateLock so that
+/// .task closures running on background threads can safely update @State.
 @propertyWrapper
 public struct State<Value: Equatable>: DynamicProperty {
-    private final class Box {
+    // @unchecked Sendable because access is synchronized via Application.stateLock
+    private final class Box: @unchecked Sendable {
+        /// Strong reference to the persistent state storage. Because this is a
+        /// reference type, it remains valid and shared even after node reconciliation
+        /// replaces the old node with a new one — both point to the same storage.
+        var storage: PersistentStateStorage?
+
+        /// Weak reference to the node, used only for setting needsRebuild.
+        /// May become nil after reconciliation, but that's fine — the rebuild
+        /// will be triggered via scheduleUpdate() regardless.
         weak var node: Node?
     }
 
@@ -26,24 +41,47 @@ public struct State<Value: Equatable>: DynamicProperty {
         self.key = "\(file):\(line)"
     }
 
-    private var resolvedNode: Node? {
-        let n = box.node ?? NodeContext.current
-        if n != nil && box.node == nil { box.node = n }
-        return n
+    /// Eagerly bind the Box to the current node's storage during the build pass.
+    public func _resolveStorage() {
+        guard box.storage == nil, let node = NodeContext.current else { return }
+        box.storage = node.persistentState
+        box.node = node
+    }
+
+    /// Resolve the storage and node from the Box or current context.
+    /// On first access during a build pass, captures both the storage and node.
+    private var resolvedStorage: PersistentStateStorage? {
+        if let storage = box.storage { return storage }
+        guard let node = NodeContext.current else { return nil }
+        box.storage = node.persistentState
+        box.node = node
+        return node.persistentState
     }
 
     public var wrappedValue: Value {
         get {
-            guard let node = resolvedNode else { return initialValue }
-            return node.persistentState[key] as? Value ?? initialValue
+            let lock = Application.shared?.stateLock
+            lock?.lock()
+            defer { lock?.unlock() }
+            guard let storage = resolvedStorage else { return initialValue }
+            return storage[key] as? Value ?? initialValue
         }
         nonmutating set {
-            guard let node = resolvedNode else { return }
-            let oldValue = node.persistentState[key]
-            node.persistentState[key] = newValue
+            let lock = Application.shared?.stateLock
+            lock?.lock()
+            guard let storage = resolvedStorage else {
+                lock?.unlock()
+                return
+            }
+            let oldValue = storage[key]
+            storage[key] = newValue
+            lock?.unlock()
 
             if !Self.isEqual(oldValue, newValue) {
-                node.needsRebuild = true
+                // needsRebuild on the node is best-effort — the node may have
+                // been replaced by reconciliation, but scheduleUpdate() is the
+                // authoritative trigger for the next rebuild pass.
+                box.node?.needsRebuild = true
                 Application.shared?.scheduleUpdate()
             }
         }
@@ -51,27 +89,43 @@ public struct State<Value: Equatable>: DynamicProperty {
 
     public var projectedValue: Binding<Value> {
         let box = self.box
-        if box.node == nil { box.node = NodeContext.current }
+        // Eagerly resolve during the build pass
+        if box.storage == nil, let node = NodeContext.current {
+            box.storage = node.persistentState
+            box.node = node
+        }
         let key = self.key
         let initialValue = self.initialValue
 
-        func resolveNode() -> Node? {
-            let node = box.node ?? NodeContext.current
-            if node != nil && box.node == nil { box.node = node }
-            return node
+        func resolveStorage() -> PersistentStateStorage? {
+            if let storage = box.storage { return storage }
+            guard let node = NodeContext.current else { return nil }
+            box.storage = node.persistentState
+            box.node = node
+            return node.persistentState
         }
 
         return Binding(
             get: {
-                guard let node = resolveNode() else { return initialValue }
-                return node.persistentState[key] as? Value ?? initialValue
+                let lock = Application.shared?.stateLock
+                lock?.lock()
+                defer { lock?.unlock() }
+                guard let storage = resolveStorage() else { return initialValue }
+                return storage[key] as? Value ?? initialValue
             },
             set: { newValue in
-                guard let node = resolveNode() else { return }
-                let oldValue = node.persistentState[key]
-                node.persistentState[key] = newValue
+                let lock = Application.shared?.stateLock
+                lock?.lock()
+                guard let storage = resolveStorage() else {
+                    lock?.unlock()
+                    return
+                }
+                let oldValue = storage[key]
+                storage[key] = newValue
+                lock?.unlock()
+
                 if !Self.isEqual(oldValue, newValue) {
-                    node.needsRebuild = true
+                    box.node?.needsRebuild = true
                     Application.shared?.scheduleUpdate()
                 }
             }
@@ -84,8 +138,19 @@ public struct State<Value: Equatable>: DynamicProperty {
     }
 }
 
-/// Marker protocol for dynamic properties
-public protocol DynamicProperty {}
+/// Marker protocol for dynamic properties.
+/// Types conforming to this protocol can be eagerly resolved during the build
+/// pass so that their internal storage references are captured while
+/// NodeContext.current is available.
+public protocol DynamicProperty {
+    /// Called during the build pass to eagerly bind internal storage references
+    /// to the current node context. The default implementation is a no-op.
+    func _resolveStorage()
+}
+
+extension DynamicProperty {
+    public func _resolveStorage() {}
+}
 
 /// Two-way binding to a value
 @propertyWrapper

--- a/Sources/Whisker/Views/Primitives/ActivityIndicator.swift
+++ b/Sources/Whisker/Views/Primitives/ActivityIndicator.swift
@@ -13,6 +13,7 @@ import Foundation
 public struct ActivityIndicator: View {
     public typealias Body = Never
 
+    /// Braille spinner frames cycled by `currentFrameIndex()`.
     static let frames: [Character] = [
         "\u{280B}", // ⠋
         "\u{2819}", // ⠙

--- a/Sources/Whisker/Views/Primitives/ActivityIndicator.swift
+++ b/Sources/Whisker/Views/Primitives/ActivityIndicator.swift
@@ -31,7 +31,7 @@ public struct ActivityIndicator: View {
     /// Create an activity indicator.
     /// - Parameter fps: Animation speed in frames per second (default: 10)
     public init(fps: Double = 10) {
-        self.fps = fps
+        self.fps = max(1, fps)
     }
 
     public var body: Never {

--- a/Sources/Whisker/Views/Primitives/ActivityIndicator.swift
+++ b/Sources/Whisker/Views/Primitives/ActivityIndicator.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// An animated spinner that cycles through Braille dot characters.
+/// Commonly used to indicate loading or in-progress operations.
+///
+/// The spinner animates automatically when in the view tree.
+/// It picks up foreground color from the environment.
+///
+///     HStack {
+///         ActivityIndicator()
+///         Text(" Loading...")
+///     }
+public struct ActivityIndicator: View {
+    public typealias Body = Never
+
+    static let frames: [Character] = [
+        "\u{280B}", // ⠋
+        "\u{2819}", // ⠙
+        "\u{2839}", // ⠹
+        "\u{2838}", // ⠸
+        "\u{283C}", // ⠼
+        "\u{2834}", // ⠴
+        "\u{2826}", // ⠦
+        "\u{2827}", // ⠧
+        "\u{2807}", // ⠇
+        "\u{280F}", // ⠏
+    ]
+
+    let fps: Double
+
+    /// Create an activity indicator.
+    /// - Parameter fps: Animation speed in frames per second (default: 10)
+    public init(fps: Double = 10) {
+        self.fps = fps
+    }
+
+    public var body: Never {
+        fatalError("ActivityIndicator has no body")
+    }
+
+    /// Compute the current frame index from wall-clock time
+    func currentFrameIndex() -> Int {
+        let time = Date().timeIntervalSinceReferenceDate
+        return Int(time * fps) % Self.frames.count
+    }
+}

--- a/Tests/WhiskerTests/WhiskerIntegrationTests.swift
+++ b/Tests/WhiskerTests/WhiskerIntegrationTests.swift
@@ -116,6 +116,12 @@ final class WhiskerIntegrationTests: XCTestCase {
         XCTAssertTrue(second.findPreviousFocusable() === first)
     }
 
+    func testTaskIdentityDistinguishesSameStringRepresentation() {
+        XCTAssertNotEqual(TaskIdentity(1), TaskIdentity("1"))
+        XCTAssertEqual(TaskIdentity(1), TaskIdentity(1))
+        XCTAssertEqual(TaskIdentity("1"), TaskIdentity("1"))
+    }
+
     func testTaskModifierSpawnsAndCompletes() {
         // Build a view tree that includes a .task modifier
         let viewBuilder = NodeViewBuilder()

--- a/Tests/WhiskerTests/WhiskerIntegrationTests.swift
+++ b/Tests/WhiskerTests/WhiskerIntegrationTests.swift
@@ -96,7 +96,7 @@ final class WhiskerIntegrationTests: XCTestCase {
         binding.wrappedValue = 7
 
         XCTAssertEqual(binding.wrappedValue, 7)
-        XCTAssertTrue(node.persistentState.values.contains { ($0 as? Int) == 7 })
+        XCTAssertTrue(node.persistentState.values.values.contains { ($0 as? Int) == 7 })
     }
 
     func testFocusTraversalOrder() {
@@ -114,6 +114,52 @@ final class WhiskerIntegrationTests: XCTestCase {
         XCTAssertTrue(root.findFirstFocusable() === first)
         XCTAssertTrue(first.findNextFocusable() === second)
         XCTAssertTrue(second.findPreviousFocusable() === first)
+    }
+
+    func testTaskModifierSpawnsAndCompletes() {
+        // Build a view tree that includes a .task modifier
+        let viewBuilder = NodeViewBuilder()
+
+        struct TaskTestView: View {
+            @State var value = 0
+            var body: some View {
+                Text("hello")
+                    .task {
+                        // This should run on a background thread
+                        value = 42
+                    }
+            }
+        }
+
+        let backend = TestBackend(size: Size(width: 40, height: 5))
+        let app = Application(mode: .inline, backend: backend) { EmptyView() }
+        defer {
+            Application.shared = nil
+            NodeContext.current = nil
+        }
+
+        let root = viewBuilder.buildNode(from: TaskTestView())
+
+        // The task should have been spawned during buildNode
+        // Find the TaskModifier node — it wraps the Text node
+        var taskNode: Node?
+        root.traverse { node in
+            if node.activeTask != nil && taskNode == nil {
+                taskNode = node
+            }
+        }
+        XCTAssertNotNil(taskNode, "Expected a node with an active task")
+
+        // Give the task time to complete (it has no sleep, should be near-instant)
+        let expectation = self.expectation(description: "Task completes")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 2)
+
+        // The @State mutation should have been written to persistentState
+        // Check if scheduleUpdate was called
+        XCTAssertTrue(app.updateScheduled, "Expected scheduleUpdate to be called by task's @State mutation")
     }
 
     func testTextFieldKeyHandlingUpdatesTextAndCursor() {


### PR DESCRIPTION
## Summary
- Adds `.task {}` and `.task(id:)` modifiers for async view lifecycle — tasks spawn on appear, cancel on removal
- Adds `ActivityIndicator` component (Braille dot spinner with configurable FPS)
- Makes `@State` thread-safe via `NSLock` so `.task` closures can mutate state from background threads
- Introduces `PersistentStateStorage` (reference type) so state survives node reconciliation in async contexts
- Updates example app with multi-phase signup flow demonstrating spinner + async

## Changes
- `TaskModifier.swift` — new modifier with `_TaskModifierProtocol` for type-erased detection
- `ActivityIndicator.swift` — Braille spinner primitive driven by wall-clock time
- `Node.swift` — `PersistentStateStorage` class, `activeTask` tracking, recursive cancellation
- `Application.swift` — `stateLock`, `animationTickCount` for continuous render during animation
- `State.swift` — lock-protected reads/writes, `_resolveStorage()` for eager binding during build pass
- `ViewBuilder.swift` — handles `TaskModifier` and `ActivityIndicator` node building, state resolution

## Test plan
- [x] Existing 39 tests pass
- [x] New `testTaskModifierSpawnsAndCompletes` verifies async task spawns and mutates `@State`
- [ ] Manual: `swift run Examples` shows spinner during signup flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a view-level `task` modifier for running async work tied to view identity.
  * Introduced an `ActivityIndicator` with configurable animation speed.
  * Example app: updated multi-phase signup flow with “Signing up...”, “Signed up!”, and a timed welcome.
* **Bug Fixes**
  * Improved async task lifecycle handling: tasks are cancelled when views change or when the app quits, and state updates are synchronized to reduce race conditions.
* **Tests**
  * Added/updated integration coverage for async `task` execution and state-bound rebuild behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->