### PR TITLE
fix: guarantee safe terminal teardown across signals and suspension

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,21 +14,42 @@ let package = Package(
         .executable(
             name: "Examples",
             targets: ["Examples"]
+        ),
+        .executable(
+            name: "WhiskerLifecycleFixture",
+            targets: ["WhiskerLifecycleFixture"]
         )
     ],
     targets: [
         .target(
             name: "Whisker",
+            dependencies: ["CWhiskerSignals"],
             path: "Sources/Whisker"
+        ),
+        .target(
+            name: "CWhiskerSignals",
+            path: "Sources/CWhiskerSignals",
+            publicHeadersPath: "include"
         ),
         .executableTarget(
             name: "Examples",
             dependencies: ["Whisker"],
             path: "Sources/Examples"
         ),
+        .executableTarget(
+            name: "WhiskerLifecycleFixture",
+            dependencies: ["Whisker"],
+            path: "Tests/WhiskerLifecycleFixture"
+        ),
+        .target(
+            name: "CWhiskerTestSupport",
+            path: "Tests/CWhiskerTestSupport",
+            publicHeadersPath: "include",
+            linkerSettings: [.linkedLibrary("util", .when(platforms: [.linux]))]
+        ),
         .testTarget(
             name: "WhiskerTests",
-            dependencies: ["Whisker"],
+            dependencies: ["Whisker", "CWhiskerTestSupport"],
             path: "Tests/WhiskerTests"
         )
     ]

--- a/Sources/CWhiskerSignals/CWhiskerSignals.c
+++ b/Sources/CWhiskerSignals/CWhiskerSignals.c
@@ -1,0 +1,239 @@
+#include "CWhiskerSignals.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+static const int handled_signals[] = {SIGINT, SIGTERM, SIGHUP, SIGTSTP};
+static const size_t handled_signal_count = sizeof(handled_signals) / sizeof(handled_signals[0]);
+
+static int pipe_fds[2] = {-1, -1};
+static struct sigaction previous_actions[4];
+static sigset_t previous_signal_mask;
+static volatile sig_atomic_t pending_signals[4];
+static int installed = 0;
+
+static int signal_index(int signal_number) {
+    for (size_t index = 0; index < handled_signal_count; index++) {
+        if (handled_signals[index] == signal_number) {
+            return (int)index;
+        }
+    }
+    return -1;
+}
+
+static void whisker_signal_handler(int signal_number) {
+    int saved_errno = errno;
+    int index = signal_index(signal_number);
+    if (index >= 0) {
+        pending_signals[index] = 1;
+    }
+
+    if (pipe_fds[1] >= 0) {
+        uint8_t wake = 1;
+        (void)write(pipe_fds[1], &wake, sizeof(wake));
+    }
+    errno = saved_errno;
+}
+
+static int configure_pipe_fd(int fd) {
+    int flags = fcntl(fd, F_GETFL);
+    if (flags == -1 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        return errno;
+    }
+
+    int descriptor_flags = fcntl(fd, F_GETFD);
+    if (descriptor_flags == -1 || fcntl(fd, F_SETFD, descriptor_flags | FD_CLOEXEC) == -1) {
+        return errno;
+    }
+    return 0;
+}
+
+static int install_handler(int signal_number) {
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = whisker_signal_handler;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = 0;
+    if (sigaction(signal_number, &action, NULL) == -1) {
+        return errno;
+    }
+    return 0;
+}
+
+int whisker_signals_install(int *read_fd) {
+    if (installed || read_fd == NULL) {
+        return EBUSY;
+    }
+
+    if (pipe(pipe_fds) == -1) {
+        return errno;
+    }
+
+    int result = configure_pipe_fd(pipe_fds[0]);
+    if (result == 0) {
+        result = configure_pipe_fd(pipe_fds[1]);
+    }
+    if (result != 0) {
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        pipe_fds[0] = -1;
+        pipe_fds[1] = -1;
+        return result;
+    }
+
+    sigset_t handled_set;
+    sigemptyset(&handled_set);
+    for (size_t index = 0; index < handled_signal_count; index++) {
+        sigaddset(&handled_set, handled_signals[index]);
+    }
+    if (sigprocmask(SIG_UNBLOCK, &handled_set, &previous_signal_mask) == -1) {
+        result = errno;
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        pipe_fds[0] = -1;
+        pipe_fds[1] = -1;
+        return result;
+    }
+
+    for (size_t index = 0; index < handled_signal_count; index++) {
+        pending_signals[index] = 0;
+    }
+
+    size_t installed_count = 0;
+    for (size_t index = 0; index < handled_signal_count; index++) {
+        if (sigaction(handled_signals[index], NULL, &previous_actions[index]) == -1) {
+            result = errno;
+            break;
+        }
+        result = install_handler(handled_signals[index]);
+        if (result != 0) {
+            break;
+        }
+        installed_count++;
+    }
+
+    if (result != 0) {
+        for (size_t index = 0; index < installed_count; index++) {
+            (void)sigaction(handled_signals[index], &previous_actions[index], NULL);
+        }
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        pipe_fds[0] = -1;
+        pipe_fds[1] = -1;
+        (void)sigprocmask(SIG_SETMASK, &previous_signal_mask, NULL);
+        return result;
+    }
+
+    installed = 1;
+    *read_fd = pipe_fds[0];
+    return 0;
+}
+
+int whisker_signals_uninstall(void) {
+    if (!installed) {
+        return 0;
+    }
+
+    int first_error = 0;
+    for (size_t index = 0; index < handled_signal_count; index++) {
+        if (sigaction(handled_signals[index], &previous_actions[index], NULL) == -1 && first_error == 0) {
+            first_error = errno;
+        }
+    }
+    if (sigprocmask(SIG_SETMASK, &previous_signal_mask, NULL) == -1 && first_error == 0) {
+        first_error = errno;
+    }
+
+    installed = 0;
+    int read_fd = pipe_fds[0];
+    int write_fd = pipe_fds[1];
+    pipe_fds[0] = -1;
+    pipe_fds[1] = -1;
+    if (read_fd >= 0 && close(read_fd) == -1 && first_error == 0) {
+        first_error = errno;
+    }
+    if (write_fd >= 0 && close(write_fd) == -1 && first_error == 0) {
+        first_error = errno;
+    }
+    return first_error;
+}
+
+int whisker_signals_drain(int *signals, size_t capacity, size_t *count) {
+    if (!installed || signals == NULL || count == NULL) {
+        return EINVAL;
+    }
+
+    uint8_t buffer[64];
+    while (read(pipe_fds[0], buffer, sizeof(buffer)) > 0) {}
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+        return errno;
+    }
+
+    sigset_t block_set;
+    sigset_t previous_set;
+    sigemptyset(&block_set);
+    for (size_t index = 0; index < handled_signal_count; index++) {
+        sigaddset(&block_set, handled_signals[index]);
+    }
+    if (sigprocmask(SIG_BLOCK, &block_set, &previous_set) == -1) {
+        return errno;
+    }
+
+    size_t written = 0;
+    for (size_t index = 0; index < handled_signal_count; index++) {
+        if (pending_signals[index]) {
+            pending_signals[index] = 0;
+            if (written < capacity) {
+                signals[written++] = handled_signals[index];
+            }
+        }
+    }
+
+    int result = 0;
+    if (sigprocmask(SIG_SETMASK, &previous_set, NULL) == -1) {
+        result = errno;
+    }
+    *count = written;
+    return result;
+}
+
+int whisker_signals_use_default(int signal_number) {
+    if (signal_index(signal_number) < 0) {
+        return EINVAL;
+    }
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = SIG_DFL;
+    sigemptyset(&action.sa_mask);
+    if (sigaction(signal_number, &action, NULL) == -1) {
+        return errno;
+    }
+    return 0;
+}
+
+int whisker_signals_rearm(int signal_number) {
+    if (!installed || signal_index(signal_number) < 0) {
+        return EINVAL;
+    }
+    return install_handler(signal_number);
+}
+
+void whisker_signals_reraise(int signal_number) {
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = SIG_DFL;
+    sigemptyset(&action.sa_mask);
+    (void)sigaction(signal_number, &action, NULL);
+
+    sigset_t unblocked;
+    sigemptyset(&unblocked);
+    sigaddset(&unblocked, signal_number);
+    (void)sigprocmask(SIG_UNBLOCK, &unblocked, NULL);
+
+    (void)kill(getpid(), signal_number);
+    _exit(128 + signal_number);
+}

--- a/Sources/CWhiskerSignals/CWhiskerSignals.c
+++ b/Sources/CWhiskerSignals/CWhiskerSignals.c
@@ -8,12 +8,13 @@
 #include <unistd.h>
 
 static const int handled_signals[] = {SIGINT, SIGTERM, SIGHUP, SIGTSTP};
-static const size_t handled_signal_count = sizeof(handled_signals) / sizeof(handled_signals[0]);
+#define HANDLED_SIGNAL_COUNT (sizeof(handled_signals) / sizeof(handled_signals[0]))
+static const size_t handled_signal_count = HANDLED_SIGNAL_COUNT;
 
 static int pipe_fds[2] = {-1, -1};
-static struct sigaction previous_actions[4];
+static struct sigaction previous_actions[HANDLED_SIGNAL_COUNT];
 static sigset_t previous_signal_mask;
-static volatile sig_atomic_t pending_signals[4];
+static volatile sig_atomic_t pending_signals[HANDLED_SIGNAL_COUNT];
 static int installed = 0;
 
 static int signal_index(int signal_number) {
@@ -90,7 +91,7 @@ int whisker_signals_install(int *read_fd) {
     for (size_t index = 0; index < handled_signal_count; index++) {
         sigaddset(&handled_set, handled_signals[index]);
     }
-    if (sigprocmask(SIG_UNBLOCK, &handled_set, &previous_signal_mask) == -1) {
+    if (sigprocmask(SIG_BLOCK, &handled_set, &previous_signal_mask) == -1) {
         result = errno;
         close(pipe_fds[0]);
         close(pipe_fds[1]);
@@ -114,6 +115,12 @@ int whisker_signals_install(int *read_fd) {
             break;
         }
         installed_count++;
+    }
+
+    // Handlers are now in place; restore the prior mask so the handled signals
+    // return to their previous (deliverable) state with our handlers installed.
+    if (result == 0 && sigprocmask(SIG_SETMASK, &previous_signal_mask, NULL) == -1) {
+        result = errno;
     }
 
     if (result != 0) {

--- a/Sources/CWhiskerSignals/include/CWhiskerSignals.h
+++ b/Sources/CWhiskerSignals/include/CWhiskerSignals.h
@@ -1,0 +1,25 @@
+#ifndef C_WHISKER_SIGNALS_H
+#define C_WHISKER_SIGNALS_H
+
+#include <stddef.h>
+
+/// Installs Whisker's signal handlers and returns the self-pipe's read descriptor.
+/// Returns zero on success or an errno value on failure.
+int whisker_signals_install(int *read_fd);
+
+/// Restores the dispositions that were active before installation and closes the pipe.
+int whisker_signals_uninstall(void);
+
+/// Drains pending signals into `signals`, returning an errno value on failure.
+int whisker_signals_drain(int *signals, size_t capacity, size_t *count);
+
+/// Temporarily restores the default disposition for a handled signal.
+int whisker_signals_use_default(int signal_number);
+
+/// Reinstalls Whisker's handler after a temporarily defaulted signal resumes.
+int whisker_signals_rearm(int signal_number);
+
+/// Resets, unblocks, and re-raises a terminating signal. This function does not return.
+void whisker_signals_reraise(int signal_number) __attribute__((noreturn));
+
+#endif

--- a/Sources/Whisker/Backend/ANSIBackend.swift
+++ b/Sources/Whisker/Backend/ANSIBackend.swift
@@ -12,6 +12,8 @@ private func tcflag(_ v: Int32) -> UInt { UInt(bitPattern: Int(v)) }
 public final class ANSIBackend: TerminalBackend, @unchecked Sendable {
     private var originalTermios: termios?
     private var outputBuffer = Data()
+    private var rawModeEnabled = false
+    private var presentationEnabled = false
 
     public var renderMode: RenderMode = .fullscreen
 
@@ -55,19 +57,32 @@ public final class ANSIBackend: TerminalBackend, @unchecked Sendable {
     }
 
     public func setup() throws {
-        var raw = termios()
-        if tcgetattr(STDIN_FILENO, &raw) == 0 {
-            originalTermios = raw
+        guard !presentationEnabled else { return }
 
-            raw.c_lflag &= ~tcflag(ECHO | ICANON | ISIG | IEXTEN)
+        if !rawModeEnabled {
+            var raw = termios()
+            guard tcgetattr(STDIN_FILENO, &raw) == 0 else {
+                throw TerminalSystemError(operation: "tcgetattr", code: errno)
+            }
+
+            if originalTermios == nil {
+                originalTermios = raw
+            }
+
+            // Keep ISIG enabled so Ctrl-C and Ctrl-Z remain SIGINT and SIGTSTP.
+            raw.c_lflag &= ~tcflag(ECHO | ICANON | IEXTEN)
             raw.c_iflag &= ~tcflag(IXON | ICRNL | BRKINT | INPCK | ISTRIP)
             raw.c_oflag &= ~tcflag(OPOST)
             raw.c_cflag |= tcflag(CS8)
             raw.c_cc.16 = 0  // VMIN
             raw.c_cc.17 = 1  // VTIME (1/10 second timeout)
 
-            tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw)
+            guard tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) == 0 else {
+                throw TerminalSystemError(operation: "enable raw terminal mode", code: errno)
+            }
+            rawModeEnabled = true
         }
+        presentationEnabled = true
 
         switch renderMode {
         case .fullscreen:
@@ -80,21 +95,34 @@ public final class ANSIBackend: TerminalBackend, @unchecked Sendable {
         flush()
     }
 
-    public func teardown() {
-        appendToBuffer(ANSI.cursorShow)
+    public func teardown() throws {
+        var firstError: Error?
 
-        switch renderMode {
-        case .fullscreen:
-            appendToBuffer(ANSI.alternateScreenOff)
-        case .inline:
-            appendToBuffer("\r\n")
+        if presentationEnabled {
+            appendToBuffer(ANSI.cursorShow)
+
+            switch renderMode {
+            case .fullscreen:
+                appendToBuffer(ANSI.alternateScreenOff)
+            case .inline:
+                appendToBuffer("\r\n")
+            }
+
+            appendToBuffer(ANSI.reset)
+            flush()
+            presentationEnabled = false
         }
 
-        appendToBuffer(ANSI.reset)
-        flush()
+        if rawModeEnabled, var original = originalTermios {
+            if tcsetattr(STDIN_FILENO, TCSAFLUSH, &original) == 0 {
+                rawModeEnabled = false
+            } else {
+                firstError = TerminalSystemError(operation: "restore terminal mode", code: errno)
+            }
+        }
 
-        if var original = originalTermios {
-            tcsetattr(STDIN_FILENO, TCSAFLUSH, &original)
+        if let firstError {
+            throw firstError
         }
     }
 

--- a/Sources/Whisker/Backend/ANSIBackend.swift
+++ b/Sources/Whisker/Backend/ANSIBackend.swift
@@ -74,8 +74,14 @@ public final class ANSIBackend: TerminalBackend, @unchecked Sendable {
             raw.c_iflag &= ~tcflag(IXON | ICRNL | BRKINT | INPCK | ISTRIP)
             raw.c_oflag &= ~tcflag(OPOST)
             raw.c_cflag |= tcflag(CS8)
-            raw.c_cc.16 = 0  // VMIN
-            raw.c_cc.17 = 1  // VTIME (1/10 second timeout)
+            // Index c_cc by the platform's named constants: VMIN/VTIME live at
+            // different offsets on Darwin vs. Linux.
+            withUnsafeMutablePointer(to: &raw.c_cc) { ccPtr in
+                ccPtr.withMemoryRebound(to: cc_t.self, capacity: Int(NCCS)) { cc in
+                    cc[Int(VMIN)] = 0   // no minimum bytes for a read
+                    cc[Int(VTIME)] = 1  // 1/10 second read timeout
+                }
+            }
 
             guard tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) == 0 else {
                 throw TerminalSystemError(operation: "enable raw terminal mode", code: errno)

--- a/Sources/Whisker/Backend/TerminalBackend.swift
+++ b/Sources/Whisker/Backend/TerminalBackend.swift
@@ -88,7 +88,7 @@ public protocol TerminalBackend: AnyObject, Sendable {
     func writeRaw(_ string: String)
     func flush()
     func setup() throws
-    func teardown()
+    func teardown() throws
     func moveCursor(to position: Position)
     func setCursorVisible(_ visible: Bool)
     func clearScreen()

--- a/Sources/Whisker/Backend/TerminalSystemError.swift
+++ b/Sources/Whisker/Backend/TerminalSystemError.swift
@@ -1,0 +1,24 @@
+#if os(macOS) || os(Linux)
+import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+/// An error reported by a POSIX operation used to manage the terminal lifecycle.
+public struct TerminalSystemError: Error, CustomStringConvertible, Sendable {
+    public let operation: String
+    public let code: Int32
+
+    public init(operation: String, code: Int32) {
+        self.operation = operation
+        self.code = code
+    }
+
+    public var description: String {
+        let message = String(cString: strerror(code))
+        return "\(operation) failed (errno \(code)): \(message)"
+    }
+}
+#endif

--- a/Sources/Whisker/Backend/TestBackend.swift
+++ b/Sources/Whisker/Backend/TestBackend.swift
@@ -35,7 +35,7 @@ public final class TestBackend: TerminalBackend, @unchecked Sendable {
         // No-op for test backend
     }
 
-    public func teardown() {
+    public func teardown() throws {
         // No-op for test backend
     }
 

--- a/Sources/Whisker/Core/Application+TerminalLifecycle.swift
+++ b/Sources/Whisker/Core/Application+TerminalLifecycle.swift
@@ -1,0 +1,65 @@
+import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+extension Application {
+    func cleanupTerminal() throws {
+        if backend.renderMode == .inline && inlineRenderer.lastRenderedLineCount > 0 {
+            let rowsDown = (inlineRenderer.lastRenderedLineCount - 1) - inlineRenderer.lastCursorContentRow
+            if rowsDown > 0 {
+                backend.writeRaw("\u{1b}[\(rowsDown)B")
+            }
+            backend.flush()
+        }
+        try backend.teardown()
+    }
+
+    func handleSignal(_ signalNumber: Int32, coordinator: SignalCoordinator) throws {
+        switch signalNumber {
+        case SIGINT, SIGTERM, SIGHUP:
+            do {
+                try cleanupTerminal()
+            } catch {
+                reportLifecycleError(error)
+            }
+
+            coordinator.reraise(signalNumber)
+
+        case SIGTSTP:
+            var teardownError: Error?
+            do {
+                try cleanupTerminal()
+            } catch {
+                teardownError = error
+                reportLifecycleError(error)
+            }
+
+            // Raise SIGSTOP rather than re-raising SIGTSTP: SIGTSTP is ignored for
+            // orphaned process groups, but SIGSTOP always suspends. Because SIGSTOP is
+            // uncatchable, our SIGTSTP handler stays installed across the stop/resume —
+            // there is no disposition to reset beforehand or rearm afterward.
+            guard kill(getpid(), SIGSTOP) == 0 else {
+                throw TerminalSystemError(operation: "suspend process", code: errno)
+            }
+
+            // Execution continues here only after SIGCONT resumes the process.
+            try backend.setup()
+            inlineRenderer.reset()
+            rebuild()
+            render()
+
+            if let teardownError { throw teardownError }
+
+        default:
+            break
+        }
+    }
+
+    private func reportLifecycleError(_ error: Error) {
+        let message = "Whisker terminal lifecycle error: \(error)\n"
+        FileHandle.standardError.write(Data(message.utf8))
+    }
+}

--- a/Sources/Whisker/Core/Application.swift
+++ b/Sources/Whisker/Core/Application.swift
@@ -22,6 +22,10 @@ public final class Application {
     var focusedIndex: Int = 0
     var updateScheduled = false
     var isRunning = false
+    /// Cleared when stdin reaches EOF (e.g. redirected input hangs up) so the run loop
+    /// stops polling a descriptor that would otherwise wake `poll()` forever. See
+    /// `waitForActivity`.
+    private var stdinOpen = true
     /// Number of animated views (e.g. `ActivityIndicator`) in the current tree.
     /// When non-zero, the run loop keeps scheduling redraws.
     var animationTickCount = 0
@@ -128,18 +132,21 @@ public final class Application {
     /// event: animation frames, and `@State` updates scheduled from async `.task` closures
     /// on another thread (those flip `updateScheduled` without touching any fd).
     private func waitForActivity(signalReadFD: Int32) throws -> Bool {
+        // A negative fd makes poll() ignore that slot (revents cleared), so once stdin
+        // hangs up we stop watching it without disturbing the fixed array layout that the
+        // revents checks below rely on.
         var fds = [
-            pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0),
+            pollfd(fd: stdinOpen ? STDIN_FILENO : -1, events: Int16(POLLIN), revents: 0),
             pollfd(fd: signalReadFD, events: Int16(POLLIN), revents: 0),
         ]
 
-        // The timeout only bounds work with no fd to wake poll(): a redraw already queued
-        // (service it now), animation frames (60fps cadence), or an idle screen (sleep,
-        // but cap it so cross-thread @State updates surface promptly).
+        // The timeout only bounds work that carries no fd event: animation frames need a
+        // ~60fps cadence; an idle screen sleeps longer, capped so cross-thread @State
+        // updates from `.task` still surface. Animation drives redraws by setting
+        // `updateScheduled`, so it must be checked on its own — keying the timeout off
+        // `updateScheduled` would collapse the frame interval to zero and busy-spin.
         let timeoutMilliseconds: Int32
-        if updateScheduled {
-            timeoutMilliseconds = 0
-        } else if animationTickCount > 0 {
+        if animationTickCount > 0 {
             timeoutMilliseconds = 16
         } else {
             timeoutMilliseconds = 50
@@ -150,7 +157,25 @@ public final class Application {
             if errno == EINTR { return false }
             throw TerminalSystemError(operation: "poll terminal input", code: errno)
         }
-        return (fds[0].revents & Int16(POLLIN)) != 0
+
+        // POLLERR/POLLNVAL stay asserted on every poll(), so a broken descriptor would
+        // spin the loop at full speed. Treat either as unrecoverable rather than looping.
+        let errorFlags = Int16(POLLERR) | Int16(POLLNVAL)
+        if (fds[1].revents & errorFlags) != 0 {
+            throw TerminalSystemError(operation: "poll signal pipe", code: EIO)
+        }
+        if (fds[0].revents & errorFlags) != 0 {
+            throw TerminalSystemError(operation: "poll terminal input", code: EIO)
+        }
+
+        // POLLHUP means stdin's source closed (e.g. redirected input reached EOF). It also
+        // stays asserted, so once any buffered input (POLLIN) is drained, stop watching
+        // stdin; signals and the timeout keep the loop alive.
+        let stdinReadable = (fds[0].revents & Int16(POLLIN)) != 0
+        if !stdinReadable && (fds[0].revents & Int16(POLLHUP)) != 0 {
+            stdinOpen = false
+        }
+        return stdinReadable
     }
 
     private func readInput() throws -> TerminalEvent? {

--- a/Sources/Whisker/Core/Application.swift
+++ b/Sources/Whisker/Core/Application.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 
 /// How the application renders to the terminal
 public enum RenderMode {
@@ -27,7 +32,7 @@ public final class Application {
     let stateLock = NSLock()
 
     private let viewBuilder = NodeViewBuilder()
-    private let inlineRenderer = InlineRenderer()
+    let inlineRenderer = InlineRenderer()
 
     public init<V: View>(mode: RenderMode = .fullscreen, backend: TerminalBackend = ANSIBackend(), @ViewBuilder rootView: @escaping () -> V) {
         self.backend = backend
@@ -37,23 +42,42 @@ public final class Application {
     }
 
     public func run() throws {
-        try backend.setup()
-        defer {
-            if backend.renderMode == .inline && inlineRenderer.lastRenderedLineCount > 0 {
-                let rowsDown = (inlineRenderer.lastRenderedLineCount - 1) - inlineRenderer.lastCursorContentRow
-                if rowsDown > 0 {
-                    backend.writeRaw("\u{1b}[\(rowsDown)B")
-                }
-                backend.flush()
-            }
-            backend.teardown()
+        let signalCoordinator: SignalCoordinator
+        do {
+            signalCoordinator = try SignalCoordinator()
+        } catch {
             Application.shared = nil
+            throw error
+        }
+        var pendingError: Error?
+
+        do {
+            try backend.setup()
+            isRunning = true
+            rebuild()
+            render()
+            try runLoop(signalCoordinator: signalCoordinator)
+        } catch {
+            pendingError = error
         }
 
-        isRunning = true
-        rebuild()
-        render()
-        runLoop()
+        isRunning = false
+        rootNode?.cancelTasksRecursively()
+
+        do {
+            try cleanupTerminal()
+        } catch {
+            if pendingError == nil { pendingError = error }
+        }
+
+        do {
+            try signalCoordinator.uninstall()
+        } catch {
+            if pendingError == nil { pendingError = error }
+        }
+
+        Application.shared = nil
+        if let pendingError { throw pendingError }
     }
 
     public func scheduleUpdate() {
@@ -67,9 +91,19 @@ public final class Application {
         rootNode?.cancelTasksRecursively()
     }
 
-    private func runLoop() {
+    private func runLoop(signalCoordinator: SignalCoordinator) throws {
         while isRunning {
-            if let event = readInput() {
+            for signalNumber in try signalCoordinator.drain() {
+                try handleSignal(signalNumber, coordinator: signalCoordinator)
+            }
+            guard isRunning else { break }
+
+            // Park until a keystroke arrives or a signal fires, instead of spinning at a
+            // fixed 60fps. Both the terminal and the signal self-pipe wake poll() the
+            // instant they have data, so this is where the loop spends its idle time.
+            let stdinReady = try waitForActivity(signalReadFD: signalCoordinator.readFileDescriptor)
+
+            if stdinReady, let event = try readInput() {
                 handleEvent(event)
             }
 
@@ -83,20 +117,65 @@ public final class Application {
             if animationTickCount > 0 {
                 updateScheduled = true
             }
-
-            // Small sleep to avoid busy-waiting
-            Thread.sleep(forTimeInterval: 0.016) // ~60fps
         }
     }
 
-    private func readInput() -> TerminalEvent? {
+    /// Blocks until stdin or the signal self-pipe becomes readable, or the timeout elapses.
+    /// Returns `true` when stdin has bytes waiting.
+    ///
+    /// Input and signals wake `poll()` immediately regardless of the timeout — the timeout
+    /// only bounds how long we sleep waiting for work that carries *no* file-descriptor
+    /// event: animation frames, and `@State` updates scheduled from async `.task` closures
+    /// on another thread (those flip `updateScheduled` without touching any fd).
+    private func waitForActivity(signalReadFD: Int32) throws -> Bool {
+        var fds = [
+            pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0),
+            pollfd(fd: signalReadFD, events: Int16(POLLIN), revents: 0),
+        ]
+
+        // The timeout only bounds work with no fd to wake poll(): a redraw already queued
+        // (service it now), animation frames (60fps cadence), or an idle screen (sleep,
+        // but cap it so cross-thread @State updates surface promptly).
+        let timeoutMilliseconds: Int32
+        if updateScheduled {
+            timeoutMilliseconds = 0
+        } else if animationTickCount > 0 {
+            timeoutMilliseconds = 16
+        } else {
+            timeoutMilliseconds = 50
+        }
+
+        let ready = poll(&fds, nfds_t(fds.count), timeoutMilliseconds)
+        if ready == -1 {
+            if errno == EINTR { return false }
+            throw TerminalSystemError(operation: "poll terminal input", code: errno)
+        }
+        return (fds[0].revents & Int16(POLLIN)) != 0
+    }
+
+    private func readInput() throws -> TerminalEvent? {
         var buffer = [UInt8](repeating: 0, count: 16)
 
         let flags = fcntl(STDIN_FILENO, F_GETFL)
-        _ = fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK)
-        defer { _ = fcntl(STDIN_FILENO, F_SETFL, flags) }
+        guard flags != -1 else {
+            throw TerminalSystemError(operation: "fcntl(F_GETFL)", code: errno)
+        }
+        guard fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK) != -1 else {
+            throw TerminalSystemError(operation: "fcntl(F_SETFL, O_NONBLOCK)", code: errno)
+        }
 
         let bytesRead = read(STDIN_FILENO, &buffer, buffer.count)
+        let readError = errno
+        guard fcntl(STDIN_FILENO, F_SETFL, flags) != -1 else {
+            throw TerminalSystemError(operation: "fcntl(F_SETFL, restore)", code: errno)
+        }
+
+        if bytesRead == -1 {
+            if readError == EAGAIN || readError == EWOULDBLOCK || readError == EINTR {
+                return nil
+            }
+            throw TerminalSystemError(operation: "read terminal input", code: readError)
+        }
         guard bytesRead > 0 else { return nil }
 
         return parseInput(Array(buffer.prefix(bytesRead)))
@@ -104,10 +183,6 @@ public final class Application {
 
     private func parseInput(_ bytes: [UInt8]) -> TerminalEvent? {
         guard !bytes.isEmpty else { return nil }
-        if bytes.count == 1, bytes[0] == 3 {
-            isRunning = false
-            return nil
-        }
         return InputParser.parse(bytes)
     }
 
@@ -149,7 +224,7 @@ public final class Application {
         }
     }
 
-    private func rebuild() {
+    func rebuild() {
         animationTickCount = 0
         let view = rootViewBuilder()
         let oldRoot = rootNode
@@ -194,7 +269,7 @@ public final class Application {
         }
     }
 
-    private func render() {
+    func render() {
         guard let root = rootNode else { return }
 
         var buffer = RenderBuffer()

--- a/Sources/Whisker/Core/Application.swift
+++ b/Sources/Whisker/Core/Application.swift
@@ -137,7 +137,7 @@ public final class Application {
         // revents checks below rely on.
         var fds = [
             pollfd(fd: stdinOpen ? STDIN_FILENO : -1, events: Int16(POLLIN), revents: 0),
-            pollfd(fd: signalReadFD, events: Int16(POLLIN), revents: 0),
+            pollfd(fd: signalReadFD, events: Int16(POLLIN), revents: 0)
         ]
 
         // The timeout only bounds work that carries no fd event: animation frames need a

--- a/Sources/Whisker/Core/InlineRenderer.swift
+++ b/Sources/Whisker/Core/InlineRenderer.swift
@@ -3,6 +3,12 @@ final class InlineRenderer {
     private(set) var lastCursorContentRow: Int = 0
     private var isFirstRender: Bool = true
 
+    func reset() {
+        lastRenderedLineCount = 0
+        lastCursorContentRow = 0
+        isFirstRender = true
+    }
+
     func render(_ buffer: RenderBuffer, backend: TerminalBackend, focusedNode: Node?) {
         let contentHeight: Int
         if buffer.commands.isEmpty {

--- a/Sources/Whisker/Core/SignalCoordinator.swift
+++ b/Sources/Whisker/Core/SignalCoordinator.swift
@@ -1,0 +1,58 @@
+#if os(macOS) || os(Linux)
+import CWhiskerSignals
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+/// Routes signals through a self-pipe so lifecycle work stays on the application thread.
+///
+/// The underlying C module keeps process-global state (one pipe, one saved-disposition
+/// table), so only one coordinator may be installed at a time. Constructing a second
+/// while one is live fails fast: `whisker_signals_install` returns `EBUSY`, surfaced here
+/// as a thrown `TerminalSystemError`. This matches Whisker's single-`Application.shared`
+/// model — a process runs one terminal UI at a time.
+final class SignalCoordinator {
+    let readFileDescriptor: Int32
+    private var isInstalled = true
+
+    init() throws {
+        var descriptor: Int32 = -1
+        let result = whisker_signals_install(&descriptor)
+        guard result == 0 else {
+            throw TerminalSystemError(operation: "install signal handlers", code: result)
+        }
+        readFileDescriptor = descriptor
+    }
+
+    deinit {
+        if isInstalled {
+            _ = whisker_signals_uninstall()
+        }
+    }
+
+    func drain() throws -> [Int32] {
+        var signals = [Int32](repeating: 0, count: 4)
+        var count = 0
+        let result = whisker_signals_drain(&signals, signals.count, &count)
+        guard result == 0 else {
+            throw TerminalSystemError(operation: "read signal pipe", code: result)
+        }
+        return Array(signals.prefix(count))
+    }
+
+    func reraise(_ signalNumber: Int32) -> Never {
+        whisker_signals_reraise(signalNumber)
+    }
+
+    func uninstall() throws {
+        guard isInstalled else { return }
+        let result = whisker_signals_uninstall()
+        isInstalled = false
+        guard result == 0 else {
+            throw TerminalSystemError(operation: "restore signal handlers", code: result)
+        }
+    }
+}
+#endif

--- a/Tests/CWhiskerTestSupport/CWhiskerTestSupport.c
+++ b/Tests/CWhiskerTestSupport/CWhiskerTestSupport.c
@@ -1,0 +1,91 @@
+#include "CWhiskerTestSupport.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+#if defined(__APPLE__)
+#include <util.h>
+#else
+#include <pty.h>
+#endif
+
+int whisker_test_spawn_pty(
+    const char *executable,
+    const char *mode,
+    pid_t *pid,
+    int *master_fd,
+    int *slave_fd
+) {
+    if (openpty(master_fd, slave_fd, NULL, NULL, NULL) == -1) {
+        return errno;
+    }
+
+    pid_t child = fork();
+    if (child == -1) {
+        int result = errno;
+        close(*master_fd);
+        close(*slave_fd);
+        return result;
+    }
+
+    if (child == 0) {
+        close(*master_fd);
+        (void)setsid();
+#ifdef TIOCSCTTY
+        (void)ioctl(*slave_fd, TIOCSCTTY, 0);
+#endif
+        if (dup2(*slave_fd, STDIN_FILENO) == -1 ||
+            dup2(*slave_fd, STDOUT_FILENO) == -1 ||
+            dup2(*slave_fd, STDERR_FILENO) == -1) {
+            _exit(126);
+        }
+        if (*slave_fd > STDERR_FILENO) {
+            close(*slave_fd);
+        }
+        execl(executable, executable, mode, NULL);
+        _exit(127);
+    }
+
+    *pid = child;
+    int flags = fcntl(*master_fd, F_GETFL);
+    if (flags == -1 || fcntl(*master_fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        return errno;
+    }
+    return 0;
+}
+
+int whisker_test_wait_for_stop(pid_t pid, int expected_signal) {
+    int status = 0;
+    for (int attempt = 0; attempt < 500; attempt++) {
+        pid_t result = waitpid(pid, &status, WUNTRACED | WNOHANG);
+        if (result == pid) {
+            return WIFSTOPPED(status) && WSTOPSIG(status) == expected_signal ? 0 : ECHILD;
+        }
+        if (result == -1) {
+            return errno;
+        }
+        usleep(10000);
+    }
+    return ETIMEDOUT;
+}
+
+int whisker_test_wait_for_signal_exit(pid_t pid, int expected_signal) {
+    int status = 0;
+    for (int attempt = 0; attempt < 500; attempt++) {
+        pid_t result = waitpid(pid, &status, WNOHANG);
+        if (result == pid) {
+            return WIFSIGNALED(status) && WTERMSIG(status) == expected_signal ? 0 : ECHILD;
+        }
+        if (result == -1) {
+            return errno;
+        }
+        usleep(10000);
+    }
+    return ETIMEDOUT;
+}

--- a/Tests/CWhiskerTestSupport/CWhiskerTestSupport.c
+++ b/Tests/CWhiskerTestSupport/CWhiskerTestSupport.c
@@ -60,21 +60,6 @@ int whisker_test_spawn_pty(
     return 0;
 }
 
-int whisker_test_wait_for_stop(pid_t pid, int expected_signal) {
-    int status = 0;
-    for (int attempt = 0; attempt < 500; attempt++) {
-        pid_t result = waitpid(pid, &status, WUNTRACED | WNOHANG);
-        if (result == pid) {
-            return WIFSTOPPED(status) && WSTOPSIG(status) == expected_signal ? 0 : ECHILD;
-        }
-        if (result == -1) {
-            return errno;
-        }
-        usleep(10000);
-    }
-    return ETIMEDOUT;
-}
-
 int whisker_test_wait_for_signal_exit(pid_t pid, int expected_signal) {
     int status = 0;
     for (int attempt = 0; attempt < 500; attempt++) {

--- a/Tests/CWhiskerTestSupport/include/CWhiskerTestSupport.h
+++ b/Tests/CWhiskerTestSupport/include/CWhiskerTestSupport.h
@@ -1,0 +1,17 @@
+#ifndef C_WHISKER_TEST_SUPPORT_H
+#define C_WHISKER_TEST_SUPPORT_H
+
+#include <sys/types.h>
+
+int whisker_test_spawn_pty(
+    const char *executable,
+    const char *mode,
+    pid_t *pid,
+    int *master_fd,
+    int *slave_fd
+);
+
+int whisker_test_wait_for_stop(pid_t pid, int expected_signal);
+int whisker_test_wait_for_signal_exit(pid_t pid, int expected_signal);
+
+#endif

--- a/Tests/CWhiskerTestSupport/include/CWhiskerTestSupport.h
+++ b/Tests/CWhiskerTestSupport/include/CWhiskerTestSupport.h
@@ -11,7 +11,6 @@ int whisker_test_spawn_pty(
     int *slave_fd
 );
 
-int whisker_test_wait_for_stop(pid_t pid, int expected_signal);
 int whisker_test_wait_for_signal_exit(pid_t pid, int expected_signal);
 
 #endif

--- a/Tests/WhiskerLifecycleFixture/main.swift
+++ b/Tests/WhiskerLifecycleFixture/main.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Whisker
+
+let argument = CommandLine.arguments.dropFirst().first
+if argument == "double-teardown" {
+    do {
+        let backend = ANSIBackend()
+        try backend.setup()
+        try backend.teardown()
+        try backend.teardown()
+        FileHandle.standardOutput.write(Data("double-teardown-complete".utf8))
+        exit(0)
+    } catch {
+        FileHandle.standardError.write(Data("fixture failed: \(error)\n".utf8))
+        exit(1)
+    }
+}
+
+let mode: RenderMode = argument == "inline" ? .inline : .fullscreen
+let app: Application
+if argument == "mock" {
+    app = Application(mode: mode, backend: TestBackend()) { Text("lifecycle-ready") }
+} else {
+    app = Application(mode: mode) { Text("lifecycle-ready") }
+}
+
+do {
+    try app.run()
+} catch {
+    FileHandle.standardError.write(Data("fixture failed: \(error)\n".utf8))
+    exit(1)
+}

--- a/Tests/WhiskerTests/TerminalLifecycleTests.swift
+++ b/Tests/WhiskerTests/TerminalLifecycleTests.swift
@@ -1,0 +1,211 @@
+import CWhiskerTestSupport
+import Foundation
+import XCTest
+
+@testable import Whisker
+
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+final class TerminalLifecycleTests: XCTestCase {
+    private struct Fixture {
+        let pid: pid_t
+        let controller: Int32
+        let terminal: Int32
+    }
+
+    private var fixtureExecutable: String {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(".build/debug/WhiskerLifecycleFixture")
+            .path
+    }
+
+    func testPartialSetupFailureStillAttemptsTeardown() {
+        let backend = FailingSetupBackend()
+        let app = Application(backend: backend) { EmptyView() }
+
+        XCTAssertThrowsError(try app.run())
+        XCTAssertEqual(backend.setupCount, 1)
+        XCTAssertEqual(backend.teardownCount, 1)
+    }
+
+    func testANSIBackendTeardownIsIdempotent() throws {
+        let fixture = try spawn(mode: "double-teardown")
+        defer { forceCleanup(fixture) }
+
+        let output = try readUntil("double-teardown-complete", from: fixture.controller)
+        XCTAssertEqual(output.components(separatedBy: "\u{1b}[?25h").count - 1, 1)
+        XCTAssertEqual(output.components(separatedBy: "\u{1b}[?1049l").count - 1, 1)
+        try assertCookedMode(fixture.controller)
+    }
+
+    func testTerminatingSignalsRetainConventionalProcessStatus() throws {
+        for signalNumber in [SIGINT, SIGTERM, SIGHUP] {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: fixtureExecutable)
+            process.arguments = ["mock"]
+            try process.run()
+            usleep(100_000)
+            XCTAssertEqual(kill(process.processIdentifier, signalNumber), 0)
+            process.waitUntilExit()
+
+            XCTAssertEqual(process.terminationReason, .uncaughtSignal)
+            XCTAssertEqual(process.terminationStatus, signalNumber)
+        }
+    }
+
+    func testTerminatingSignalRestoresFullscreenTerminal() throws {
+        let fixture = try spawn(mode: "fullscreen")
+        defer { forceCleanup(fixture) }
+
+        var output = try readUntil("\u{1b}[?1049h", from: fixture.controller)
+        XCTAssertEqual(kill(fixture.pid, SIGTERM), 0)
+        output += try readUntil("\u{1b}[?1049l", from: fixture.controller)
+
+        XCTAssertTrue(output.contains("\u{1b}[?25h"))
+        XCTAssertTrue(output.contains("\u{1b}[0m"))
+        try assertCookedMode(fixture.controller)
+    }
+
+    func testInlineSignalCleanupDoesNotUseAlternateScreen() throws {
+        let fixture = try spawn(mode: "inline")
+        defer { forceCleanup(fixture) }
+
+        var output = try readUntil("\u{1b}[?25l", from: fixture.controller)
+        XCTAssertEqual(kill(fixture.pid, SIGTERM), 0)
+        output += try readUntil("\u{1b}[?25h", from: fixture.controller)
+
+        XCTAssertFalse(output.contains("\u{1b}[?1049h"))
+        XCTAssertFalse(output.contains("\u{1b}[?1049l"))
+        XCTAssertTrue(output.contains("\u{1b}[?25h"))
+        try assertCookedMode(fixture.controller)
+    }
+
+    func testSuspendRestoresThenResumeReentersConfiguredMode() throws {
+        let fixture = try spawn(mode: "fullscreen")
+        defer { forceCleanup(fixture) }
+
+        var output = try readUntil("\u{1b}[?1049h", from: fixture.controller)
+        XCTAssertEqual(kill(fixture.pid, SIGTSTP), 0)
+        output += try readUntil("\u{1b}[?1049l", from: fixture.controller)
+
+        XCTAssertTrue(output.contains("\u{1b}[?1049l"))
+        try assertCookedMode(fixture.controller)
+
+        XCTAssertEqual(kill(fixture.pid, SIGCONT), 0)
+        let resumedOutput = try readUntil("\u{1b}[?1049h", from: fixture.controller)
+        XCTAssertTrue(resumedOutput.contains("\u{1b}[?25l"))
+        try assertRawModeWithSignals(fixture.controller)
+
+        XCTAssertEqual(kill(fixture.pid, SIGTERM), 0)
+        _ = try readUntil("\u{1b}[?1049l", from: fixture.controller)
+        try assertCookedMode(fixture.controller)
+    }
+
+    private func spawn(mode: String) throws -> Fixture {
+        var pid: pid_t = 0
+        var controller: Int32 = -1
+        var terminal: Int32 = -1
+        let result = fixtureExecutable.withCString { executable in
+            mode.withCString { modePointer in
+                whisker_test_spawn_pty(executable, modePointer, &pid, &controller, &terminal)
+            }
+        }
+        guard result == 0 else {
+            throw TerminalSystemError(operation: "spawn PTY fixture", code: result)
+        }
+        return Fixture(pid: pid, controller: controller, terminal: terminal)
+    }
+
+    private func forceCleanup(_ fixture: Fixture) {
+        _ = kill(fixture.pid, SIGKILL)
+        _ = whisker_test_wait_for_signal_exit(fixture.pid, SIGKILL)
+        close(fixture.controller)
+        close(fixture.terminal)
+    }
+
+    private func readUntil(_ marker: String, from descriptor: Int32, timeout: TimeInterval = 3) throws -> String {
+        let deadline = Date().addingTimeInterval(timeout)
+        var output = ""
+        while Date() < deadline {
+            output += readAvailable(from: descriptor)
+            if output.contains(marker) { return output }
+            usleep(10_000)
+        }
+        XCTFail("Timed out waiting for terminal output marker \(String(reflecting: marker)); output: \(String(reflecting: output))")
+        return output
+    }
+
+    private func readAvailable(from descriptor: Int32) -> String {
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = read(descriptor, &buffer, buffer.count)
+            if count > 0 {
+                data.append(contentsOf: buffer.prefix(count))
+            } else {
+                break
+            }
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private func assertCookedMode(_ descriptor: Int32, file: StaticString = #filePath, line: UInt = #line) throws {
+        let deadline = Date().addingTimeInterval(1)
+        var attributes = termios()
+        repeat {
+            guard tcgetattr(descriptor, &attributes) == 0 else {
+                throw TerminalSystemError(operation: "inspect cooked terminal mode", code: errno)
+            }
+            if attributes.c_lflag & tcflag_t(ICANON) != 0,
+               attributes.c_lflag & tcflag_t(ECHO) != 0 {
+                return
+            }
+            usleep(10_000)
+        } while Date() < deadline
+
+        XCTAssertNotEqual(attributes.c_lflag & tcflag_t(ICANON), 0, file: file, line: line)
+        XCTAssertNotEqual(attributes.c_lflag & tcflag_t(ECHO), 0, file: file, line: line)
+    }
+
+    private func assertRawModeWithSignals(_ descriptor: Int32, file: StaticString = #filePath, line: UInt = #line) throws {
+        var attributes = termios()
+        guard tcgetattr(descriptor, &attributes) == 0 else {
+            throw TerminalSystemError(operation: "inspect raw terminal mode", code: errno)
+        }
+        XCTAssertEqual(attributes.c_lflag & tcflag_t(ICANON), 0, file: file, line: line)
+        XCTAssertNotEqual(attributes.c_lflag & tcflag_t(ISIG), 0, file: file, line: line)
+    }
+}
+
+private final class FailingSetupBackend: TerminalBackend, @unchecked Sendable {
+    enum ExpectedError: Error { case setup }
+
+    var renderMode: RenderMode = .fullscreen
+    var size = Size(width: 80, height: 24)
+    var setupCount = 0
+    var teardownCount = 0
+
+    func write(_ commands: [RenderCommand]) {}
+    func writeRaw(_ string: String) {}
+    func flush() {}
+    func moveCursor(to position: Position) {}
+    func setCursorVisible(_ visible: Bool) {}
+    func clearScreen() {}
+    func clearLines(_ count: Int) {}
+
+    func setup() throws {
+        setupCount += 1
+        throw ExpectedError.setup
+    }
+
+    func teardown() throws {
+        teardownCount += 1
+    }
+}


### PR DESCRIPTION
## Summary

- restore terminal state for normal exit, `SIGINT`, `SIGTERM`, and `SIGHUP`
- restore before suspension and re-enter the configured terminal mode after resume
- preserve conventional signal termination by resetting and re-raising fatal signals
- move signal capture into an async-signal-safe C self-pipe shim
- make terminal setup and teardown checked, idempotent, and safe after partial setup
- replace the fixed spin loop with `poll()` while preserving animation cadence and handling descriptor hangups/errors
- add isolated process and PTY lifecycle coverage for fullscreen and inline modes

## Why

Terminal cleanup previously depended on the normal `defer` path. Signal termination could bypass it and leave the user's shell in raw mode, with the cursor hidden or the alternate screen still active. The previous raw-mode configuration also disabled `ISIG`, so Ctrl-C and Ctrl-Z did not retain conventional signal behavior.

## Developer impact

`TerminalBackend.teardown()` can now throw so lifecycle syscall failures are surfaced. Existing nonthrowing conformances remain valid implementations of the throwing protocol requirement.

## Validation

- `swift test` — 46 tests passed
- focused SwiftLint on changed lifecycle Swift files — passed
- `git diff --check` — passed

The repository-wide SwiftLint run still reports two violations already present on `main` in `ViewBuilder.swift` and `ActivityIndicator.swift`.

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal lifecycle handling, including cleanup and restoration during termination and suspend/resume events.
  * Added signal-aware application processing for more reliable interrupt and suspension behavior.
  * Added clearer terminal system error reporting.
  * Prevented repeated input polling after redirected input reaches EOF.

* **Bug Fixes**
  * Made terminal setup and teardown safe to call repeatedly.
  * Improved error handling for terminal and input operations.

* **Tests**
  * Added comprehensive coverage for terminal restoration, lifecycle transitions, signal handling, and partial setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->