### PR TITLE
feat: collapse large TextField pastes into atomic markers

### DIFF
--- a/Sources/Whisker/Core/Application.swift
+++ b/Sources/Whisker/Core/Application.swift
@@ -269,8 +269,10 @@ public final class Application {
         switch event {
         case .key(let keyEvent):
             return handleKey(keyEvent)
-        case .text(let text), .paste(let text):
-            return handleText(text)
+        case .text(let text):
+            return handleText(text, isPaste: false)
+        case .paste(let text):
+            return handleText(text, isPaste: true)
         case .resize(let size):
             // Relayout and rerender
             if let root = rootNode {
@@ -299,9 +301,11 @@ public final class Application {
         return false
     }
 
-    private func handleText(_ text: String) -> Bool {
+    private func handleText(_ text: String, isPaste: Bool) -> Bool {
         guard let focused = focusedNode else { return false }
-        if let handler = focused[.textInputHandler] {
+        if isPaste, let pasteHandler = focused[.pasteInputHandler] {
+            pasteHandler(text)
+        } else if let handler = focused[.textInputHandler] {
             handler(text)
         } else {
             for character in text {

--- a/Sources/Whisker/Core/NodeStorage.swift
+++ b/Sources/Whisker/Core/NodeStorage.swift
@@ -2,11 +2,14 @@
 enum NodeStorageKey {
     static let keyHandler = NodeKey<(KeyEvent) -> Void>("_keyHandler")
     static let textInputHandler = NodeKey<(String) -> Void>("_textInputHandler")
+    static let pasteInputHandler = NodeKey<(String) -> Void>("_pasteInputHandler")
     static let getText = NodeKey<() -> String>("_getText")
     static let setText = NodeKey<(String) -> Void>("_setText")
     static let placeholder = NodeKey<String>("_placeholder")
     static let cursorPosition = NodeKey<Int>("_cursorPosition")
     static let isSecure = NodeKey<Bool>("_isSecure")
+    static let displayText = NodeKey<String>("_displayText")
+    static let pasteStore = NodeKey<[String: String]>("_pasteStore")
     static let action = NodeKey<() -> Void>("_action")
     static let label = NodeKey<String>("_label")
     static let placeChildren = NodeKey<(Rect) -> Void>("_placeChildren")
@@ -27,11 +30,14 @@ extension Node {
 extension NodeKey {
     static var keyHandler: NodeKey<(KeyEvent) -> Void> { NodeStorageKey.keyHandler }
     static var textInputHandler: NodeKey<(String) -> Void> { NodeStorageKey.textInputHandler }
+    static var pasteInputHandler: NodeKey<(String) -> Void> { NodeStorageKey.pasteInputHandler }
     static var getText: NodeKey<() -> String> { NodeStorageKey.getText }
     static var setText: NodeKey<(String) -> Void> { NodeStorageKey.setText }
     static var placeholder: NodeKey<String> { NodeStorageKey.placeholder }
     static var cursorPosition: NodeKey<Int> { NodeStorageKey.cursorPosition }
     static var isSecure: NodeKey<Bool> { NodeStorageKey.isSecure }
+    static var displayText: NodeKey<String> { NodeStorageKey.displayText }
+    static var pasteStore: NodeKey<[String: String]> { NodeStorageKey.pasteStore }
     static var action: NodeKey<() -> Void> { NodeStorageKey.action }
     static var label: NodeKey<String> { NodeStorageKey.label }
     static var placeChildren: NodeKey<(Rect) -> Void> { NodeStorageKey.placeChildren }

--- a/Sources/Whisker/Core/PasteCollapse.swift
+++ b/Sources/Whisker/Core/PasteCollapse.swift
@@ -45,8 +45,13 @@ enum PasteCollapse {
         "\(sentinelStart)\(id)\(sentinelEnd)"
     }
 
-    /// Scans `displayText` for well-formed sentinel spans.
-    static func sentinelSpans(in displayText: String) -> [SentinelSpan] {
+    /// Scans `displayText` for well-formed sentinel spans whose id exists in
+    /// `store`. Sentinel-shaped sequences with unknown ids are literal text,
+    /// so arbitrary input can never alias a paste marker.
+    static func sentinelSpans(
+        in displayText: String,
+        store: [String: String]
+    ) -> [SentinelSpan] {
         var spans: [SentinelSpan] = []
         var offset = 0
         var index = displayText.startIndex
@@ -69,10 +74,11 @@ enum PasteCollapse {
                     offset += 1
                 }
 
+                let id = String(idChars)
                 if index < displayText.endIndex,
                    displayText[index] == sentinelEnd,
                    idChars.count == 8,
-                   idChars.allSatisfy({ $0.isHexDigit })
+                   store[id] != nil
                 {
                     displayText.formIndex(after: &index)
                     offset += 1
@@ -82,13 +88,13 @@ enum PasteCollapse {
                             range: startIndex..<endIndex,
                             startOffset: startOffset,
                             length: offset - startOffset,
-                            id: String(idChars)
+                            id: id
                         )
                     )
                     continue
                 }
 
-                // Malformed — treat as ordinary characters already consumed.
+                // Malformed or unknown id — literal characters already consumed.
                 continue
             }
 
@@ -99,18 +105,30 @@ enum PasteCollapse {
         return spans
     }
 
-    static func span(atOffset offset: Int, in displayText: String) -> SentinelSpan? {
-        sentinelSpans(in: displayText).first {
+    static func span(
+        atOffset offset: Int,
+        in displayText: String,
+        store: [String: String]
+    ) -> SentinelSpan? {
+        sentinelSpans(in: displayText, store: store).first {
             offset >= $0.startOffset && offset < $0.endOffset
         }
     }
 
-    static func spanEnding(at offset: Int, in displayText: String) -> SentinelSpan? {
-        sentinelSpans(in: displayText).first { $0.endOffset == offset }
+    static func spanEnding(
+        at offset: Int,
+        in displayText: String,
+        store: [String: String]
+    ) -> SentinelSpan? {
+        sentinelSpans(in: displayText, store: store).first { $0.endOffset == offset }
     }
 
-    static func spanStarting(at offset: Int, in displayText: String) -> SentinelSpan? {
-        sentinelSpans(in: displayText).first { $0.startOffset == offset }
+    static func spanStarting(
+        at offset: Int,
+        in displayText: String,
+        store: [String: String]
+    ) -> SentinelSpan? {
+        sentinelSpans(in: displayText, store: store).first { $0.startOffset == offset }
     }
 
     // MARK: - Expand / visual
@@ -119,7 +137,7 @@ enum PasteCollapse {
         var result = ""
         var offset = 0
         var index = displayText.startIndex
-        let spans = sentinelSpans(in: displayText)
+        let spans = sentinelSpans(in: displayText, store: store)
         var spanIndex = 0
 
         while index < displayText.endIndex {
@@ -143,7 +161,7 @@ enum PasteCollapse {
         var result = ""
         var offset = 0
         var index = displayText.startIndex
-        let spans = sentinelSpans(in: displayText)
+        let spans = sentinelSpans(in: displayText, store: store)
         var spanIndex = 0
 
         while index < displayText.endIndex {
@@ -176,7 +194,7 @@ enum PasteCollapse {
         var width = 0
         var offset = 0
         var index = displayText.startIndex
-        let spans = sentinelSpans(in: displayText)
+        let spans = sentinelSpans(in: displayText, store: store)
         var spanIndex = 0
 
         while offset < clamped, index < displayText.endIndex {
@@ -214,9 +232,13 @@ enum PasteCollapse {
     // MARK: - Atomic editing
 
     /// Moves the cursor left across a sentinel as one unit if adjacent.
-    static func moveLeft(cursor: inout Int, in displayText: String) {
+    static func moveLeft(
+        cursor: inout Int,
+        in displayText: String,
+        store: [String: String]
+    ) {
         guard cursor > 0 else { return }
-        if let span = spanEnding(at: cursor, in: displayText) {
+        if let span = spanEnding(at: cursor, in: displayText, store: store) {
             cursor = span.startOffset
         } else {
             cursor -= 1
@@ -224,10 +246,14 @@ enum PasteCollapse {
     }
 
     /// Moves the cursor right across a sentinel as one unit if adjacent.
-    static func moveRight(cursor: inout Int, in displayText: String) {
+    static func moveRight(
+        cursor: inout Int,
+        in displayText: String,
+        store: [String: String]
+    ) {
         let maxOffset = displayText.count
         guard cursor < maxOffset else { return }
-        if let span = spanStarting(at: cursor, in: displayText) {
+        if let span = spanStarting(at: cursor, in: displayText, store: store) {
             cursor = span.endOffset
         } else {
             cursor += 1
@@ -243,7 +269,7 @@ enum PasteCollapse {
         store: inout [String: String]
     ) -> String? {
         guard cursor > 0 else { return nil }
-        if let span = spanEnding(at: cursor, in: displayText) {
+        if let span = spanEnding(at: cursor, in: displayText, store: store) {
             let id = span.id
             displayText.removeSubrange(span.range)
             store.removeValue(forKey: id)
@@ -265,7 +291,7 @@ enum PasteCollapse {
         store: inout [String: String]
     ) -> String? {
         guard cursor < displayText.count else { return nil }
-        if let span = spanStarting(at: cursor, in: displayText) {
+        if let span = spanStarting(at: cursor, in: displayText, store: store) {
             let id = span.id
             displayText.removeSubrange(span.range)
             store.removeValue(forKey: id)
@@ -295,7 +321,10 @@ enum PasteCollapse {
         cursor: inout Int,
         store: inout [String: String]
     ) -> String {
-        let id = makeID()
+        var id = makeID()
+        while store[id] != nil {
+            id = makeID()
+        }
         store[id] = payload
         let sentinel = makeSentinel(id: id)
         insertRaw(sentinel, into: &displayText, cursor: &cursor)

--- a/Sources/Whisker/Core/PasteCollapse.swift
+++ b/Sources/Whisker/Core/PasteCollapse.swift
@@ -1,0 +1,302 @@
+/// Collapses large pastes into atomic display markers while keeping bindings expanded.
+enum PasteCollapse {
+    /// Pastes with at least this many whitespace-separated words become markers.
+    static let defaultWordThreshold = 50
+
+    static let sentinelStart: Character = "\u{E000}"
+    static let sentinelEnd: Character = "\u{E001}"
+
+    /// A contiguous sentinel span in display text: `\u{E000}` + 8 hex id + `\u{E001}`.
+    struct SentinelSpan {
+        let range: Range<String.Index>
+        /// Character offset of `range.lowerBound` from `startIndex`.
+        let startOffset: Int
+        /// Character length of the sentinel span.
+        let length: Int
+        let id: String
+
+        var endOffset: Int { startOffset + length }
+    }
+
+    // MARK: - Word counting & labels
+
+    static func wordCount(_ text: String) -> Int {
+        text.split { $0.isWhitespace }.count
+    }
+
+    static func shouldCollapse(_ text: String, threshold: Int = defaultWordThreshold) -> Bool {
+        wordCount(text) >= threshold
+    }
+
+    static func label(forPayload payload: String) -> String {
+        let count = wordCount(payload)
+        return count == 1 ? "[Pasted 1 word]" : "[Pasted \(count) words]"
+    }
+
+    // MARK: - Sentinels
+
+    static func makeID() -> String {
+        String(format: "%08x", UInt32.random(in: 0...UInt32.max))
+    }
+
+    static func makeSentinel(id: String) -> String {
+        "\(sentinelStart)\(id)\(sentinelEnd)"
+    }
+
+    /// Scans `displayText` for well-formed sentinel spans.
+    static func sentinelSpans(in displayText: String) -> [SentinelSpan] {
+        var spans: [SentinelSpan] = []
+        var offset = 0
+        var index = displayText.startIndex
+
+        while index < displayText.endIndex {
+            let character = displayText[index]
+            if character == sentinelStart {
+                let startIndex = index
+                let startOffset = offset
+                displayText.formIndex(after: &index)
+                offset += 1
+
+                var idChars: [Character] = []
+                while index < displayText.endIndex,
+                      displayText[index] != sentinelEnd,
+                      idChars.count < 8
+                {
+                    idChars.append(displayText[index])
+                    displayText.formIndex(after: &index)
+                    offset += 1
+                }
+
+                if index < displayText.endIndex,
+                   displayText[index] == sentinelEnd,
+                   idChars.count == 8,
+                   idChars.allSatisfy({ $0.isHexDigit })
+                {
+                    displayText.formIndex(after: &index)
+                    offset += 1
+                    let endIndex = index
+                    spans.append(
+                        SentinelSpan(
+                            range: startIndex..<endIndex,
+                            startOffset: startOffset,
+                            length: offset - startOffset,
+                            id: String(idChars)
+                        )
+                    )
+                    continue
+                }
+
+                // Malformed — treat as ordinary characters already consumed.
+                continue
+            }
+
+            displayText.formIndex(after: &index)
+            offset += 1
+        }
+
+        return spans
+    }
+
+    static func span(atOffset offset: Int, in displayText: String) -> SentinelSpan? {
+        sentinelSpans(in: displayText).first {
+            offset >= $0.startOffset && offset < $0.endOffset
+        }
+    }
+
+    static func spanEnding(at offset: Int, in displayText: String) -> SentinelSpan? {
+        sentinelSpans(in: displayText).first { $0.endOffset == offset }
+    }
+
+    static func spanStarting(at offset: Int, in displayText: String) -> SentinelSpan? {
+        sentinelSpans(in: displayText).first { $0.startOffset == offset }
+    }
+
+    // MARK: - Expand / visual
+
+    static func expand(displayText: String, store: [String: String]) -> String {
+        var result = ""
+        var offset = 0
+        var index = displayText.startIndex
+        let spans = sentinelSpans(in: displayText)
+        var spanIndex = 0
+
+        while index < displayText.endIndex {
+            if spanIndex < spans.count, spans[spanIndex].startOffset == offset {
+                let span = spans[spanIndex]
+                result += store[span.id] ?? ""
+                index = span.range.upperBound
+                offset = span.endOffset
+                spanIndex += 1
+            } else {
+                result.append(displayText[index])
+                displayText.formIndex(after: &index)
+                offset += 1
+            }
+        }
+
+        return result
+    }
+
+    static func visualString(displayText: String, store: [String: String]) -> String {
+        var result = ""
+        var offset = 0
+        var index = displayText.startIndex
+        let spans = sentinelSpans(in: displayText)
+        var spanIndex = 0
+
+        while index < displayText.endIndex {
+            if spanIndex < spans.count, spans[spanIndex].startOffset == offset {
+                let span = spans[spanIndex]
+                if let payload = store[span.id] {
+                    result += label(forPayload: payload)
+                }
+                index = span.range.upperBound
+                offset = span.endOffset
+                spanIndex += 1
+            } else {
+                result.append(displayText[index])
+                displayText.formIndex(after: &index)
+                offset += 1
+            }
+        }
+
+        return result
+    }
+
+    /// Visual column width of the display prefix up to `characterOffset`.
+    static func visualWidth(
+        displayText: String,
+        store: [String: String],
+        upToCharacterOffset characterOffset: Int,
+        replacingControlCharacters: Bool = true
+    ) -> Int {
+        let clamped = min(max(0, characterOffset), displayText.count)
+        var width = 0
+        var offset = 0
+        var index = displayText.startIndex
+        let spans = sentinelSpans(in: displayText)
+        var spanIndex = 0
+
+        while offset < clamped, index < displayText.endIndex {
+            if spanIndex < spans.count, spans[spanIndex].startOffset == offset {
+                let span = spans[spanIndex]
+                if clamped <= span.startOffset {
+                    break
+                }
+                // Cursor inside a sentinel (shouldn't happen with atomic nav) —
+                // count full label once we enter the span.
+                if let payload = store[span.id] {
+                    width += terminalTextWidth(
+                        label(forPayload: payload),
+                        replacingControlCharacters: replacingControlCharacters
+                    )
+                }
+                index = span.range.upperBound
+                offset = span.endOffset
+                spanIndex += 1
+                continue
+            }
+
+            let character = displayText[index]
+            let rendered = replacingControlCharacters
+                ? terminalSafeCharacter(character)
+                : character
+            width += terminalCellWidth(rendered)
+            displayText.formIndex(after: &index)
+            offset += 1
+        }
+
+        return width
+    }
+
+    // MARK: - Atomic editing
+
+    /// Moves the cursor left across a sentinel as one unit if adjacent.
+    static func moveLeft(cursor: inout Int, in displayText: String) {
+        guard cursor > 0 else { return }
+        if let span = spanEnding(at: cursor, in: displayText) {
+            cursor = span.startOffset
+        } else {
+            cursor -= 1
+        }
+    }
+
+    /// Moves the cursor right across a sentinel as one unit if adjacent.
+    static func moveRight(cursor: inout Int, in displayText: String) {
+        let maxOffset = displayText.count
+        guard cursor < maxOffset else { return }
+        if let span = spanStarting(at: cursor, in: displayText) {
+            cursor = span.endOffset
+        } else {
+            cursor += 1
+        }
+    }
+
+    /// Deletes the sentinel ending at `cursor` (backspace), or one character.
+    /// Returns the removed paste id if a sentinel was deleted.
+    @discardableResult
+    static func backspace(
+        displayText: inout String,
+        cursor: inout Int,
+        store: inout [String: String]
+    ) -> String? {
+        guard cursor > 0 else { return nil }
+        if let span = spanEnding(at: cursor, in: displayText) {
+            let id = span.id
+            displayText.removeSubrange(span.range)
+            store.removeValue(forKey: id)
+            cursor = span.startOffset
+            return id
+        }
+
+        let index = displayText.index(displayText.startIndex, offsetBy: cursor - 1)
+        displayText.remove(at: index)
+        cursor -= 1
+        return nil
+    }
+
+    /// Deletes the sentinel starting at `cursor` (forward delete), or one character.
+    @discardableResult
+    static func deleteForward(
+        displayText: inout String,
+        cursor: inout Int,
+        store: inout [String: String]
+    ) -> String? {
+        guard cursor < displayText.count else { return nil }
+        if let span = spanStarting(at: cursor, in: displayText) {
+            let id = span.id
+            displayText.removeSubrange(span.range)
+            store.removeValue(forKey: id)
+            return id
+        }
+
+        let index = displayText.index(displayText.startIndex, offsetBy: cursor)
+        displayText.remove(at: index)
+        return nil
+    }
+
+    /// Inserts raw text at the cursor into `displayText`.
+    static func insertRaw(
+        _ inserted: String,
+        into displayText: inout String,
+        cursor: inout Int
+    ) {
+        let insertionIndex = displayText.index(displayText.startIndex, offsetBy: cursor)
+        displayText.insert(contentsOf: inserted, at: insertionIndex)
+        cursor += inserted.count
+    }
+
+    /// Inserts a collapsed paste sentinel at the cursor and stores the payload.
+    static func insertCollapsedPaste(
+        _ payload: String,
+        into displayText: inout String,
+        cursor: inout Int,
+        store: inout [String: String]
+    ) -> String {
+        let id = makeID()
+        store[id] = payload
+        let sentinel = makeSentinel(id: id)
+        insertRaw(sentinel, into: &displayText, cursor: &cursor)
+        return id
+    }
+}

--- a/Sources/Whisker/Core/PasteCollapse.swift
+++ b/Sources/Whisker/Core/PasteCollapse.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Collapses large pastes into atomic display markers while keeping bindings expanded.
 enum PasteCollapse {
     /// Pastes with at least this many whitespace-separated words become markers.

--- a/Sources/Whisker/Core/ViewBuilder+Controls.swift
+++ b/Sources/Whisker/Core/ViewBuilder+Controls.swift
@@ -176,9 +176,9 @@ extension NodeViewBuilder {
         case .delete:
             PasteCollapse.deleteForward(displayText: &displayText, cursor: &cursor, store: &store)
         case .left:
-            PasteCollapse.moveLeft(cursor: &cursor, in: displayText)
+            PasteCollapse.moveLeft(cursor: &cursor, in: displayText, store: store)
         case .right:
-            PasteCollapse.moveRight(cursor: &cursor, in: displayText)
+            PasteCollapse.moveRight(cursor: &cursor, in: displayText, store: store)
         case .home:
             cursor = 0
         case .end:

--- a/Sources/Whisker/Core/ViewBuilder+Controls.swift
+++ b/Sources/Whisker/Core/ViewBuilder+Controls.swift
@@ -37,96 +37,152 @@ extension NodeViewBuilder {
         node[.placeholder] = placeholder
         node[.isSecure] = isSecure
 
-        // Preserve cursor position from old node, or default to end of text
+        let bindingText = getText()
+        reconcileDisplayBuffer(for: node, bindingText: bindingText, existing: existing)
+
+        let displayText = node[.displayText] ?? bindingText
         if let existing = existing, let oldCursor = existing[.cursorPosition] {
-            node[.cursorPosition] = min(oldCursor, getText().count)
+            node[.cursorPosition] = min(oldCursor, displayText.count)
         } else {
-            node[.cursorPosition] = getText().count
+            node[.cursorPosition] = displayText.count
         }
 
         let secureFieldWidth = 20
 
         node[.keyHandler] = makeInputFieldKeyHandler(for: node)
         node[.textInputHandler] = makeInputFieldTextHandler(for: node)
+        node[.pasteInputHandler] = makeInputFieldPasteHandler(for: node)
         node.render = makeInputFieldRenderClosure(for: node, isSecure: isSecure)
 
         node.layout = { [weak node] proposal, _ in
             guard let node = node else { return (.zero, []) }
-            let text = node[.getText]?() ?? ""
             let placeholder = node[.placeholder] ?? ""
-            let displayText = text.isEmpty ? placeholder : text
+            let store = node[.pasteStore] ?? [:]
+            let rawDisplay = node[.displayText] ?? ""
+            let visual = isSecure
+                ? rawDisplay
+                : PasteCollapse.visualString(displayText: rawDisplay, store: store)
+            let shown = visual.isEmpty ? placeholder : visual
             let displayWidth = isSecure
                 ? secureFieldWidth
-                : terminalTextWidth(displayText, replacingControlCharacters: true)
+                : terminalTextWidth(shown, replacingControlCharacters: true)
             let width = proposal.width.resolve(with: displayWidth)
             return (Size(width: width, height: 1), [])
         }
     }
 
+    private func reconcileDisplayBuffer(
+        for node: Node,
+        bindingText: String,
+        existing: Node?
+    ) {
+        if let existing,
+           let previousDisplay = existing[.displayText]
+        {
+            let previousStore = existing[.pasteStore] ?? [:]
+            let expanded = PasteCollapse.expand(displayText: previousDisplay, store: previousStore)
+            if expanded == bindingText {
+                node[.displayText] = previousDisplay
+                node[.pasteStore] = previousStore
+                return
+            }
+        }
+
+        node[.displayText] = bindingText
+        node[.pasteStore] = [:]
+    }
+
+    private static func syncBinding(from node: Node) {
+        guard let setText = node[.setText] else { return }
+        let displayText = node[.displayText] ?? ""
+        let store = node[.pasteStore] ?? [:]
+        setText(PasteCollapse.expand(displayText: displayText, store: store))
+    }
+
     private func makeInputFieldKeyHandler(for node: Node) -> (KeyEvent) -> Void {
         return { [weak node] (event: KeyEvent) in
             guard let node = node else { return }
-            guard let getText = node[.getText],
-                let setText = node[.setText]
-            else { return }
+            var displayText = node[.displayText] ?? ""
+            var store = node[.pasteStore] ?? [:]
+            var cursor = node[.cursorPosition] ?? displayText.count
+            NodeViewBuilder.applyKeyEdit(
+                event.key,
+                displayText: &displayText,
+                cursor: &cursor,
+                store: &store
+            )
 
-            var text = getText()
-            var cursor = node[.cursorPosition] ?? text.count
-            NodeViewBuilder.applyKeyEdit(event.key, text: &text, cursor: &cursor)
-
-            setText(text)
+            node[.displayText] = displayText
+            node[.pasteStore] = store
             node[.cursorPosition] = cursor
+            NodeViewBuilder.syncBinding(from: node)
             Application.shared?.scheduleUpdate()
         }
     }
 
     private func makeInputFieldTextHandler(for node: Node) -> (String) -> Void {
         return { [weak node] insertedText in
-            guard let node,
-                  let getText = node[.getText],
-                  let setText = node[.setText]
-            else { return }
-
-            let text = getText()
-            let cursor = min(max(0, node[.cursorPosition] ?? text.count), text.count)
-            let insertionIndex = text.index(text.startIndex, offsetBy: cursor)
-            let prefix = String(text[..<insertionIndex])
-            let suffix = String(text[insertionIndex...])
-            let textThroughInsertion = prefix + insertedText
-
-            setText(textThroughInsertion + suffix)
-            node[.cursorPosition] = textThroughInsertion.count
+            guard let node else { return }
+            var displayText = node[.displayText] ?? ""
+            var cursor = min(max(0, node[.cursorPosition] ?? displayText.count), displayText.count)
+            PasteCollapse.insertRaw(insertedText, into: &displayText, cursor: &cursor)
+            node[.displayText] = displayText
+            node[.cursorPosition] = cursor
+            NodeViewBuilder.syncBinding(from: node)
             Application.shared?.scheduleUpdate()
         }
     }
 
-    private static func applyKeyEdit(_ key: Key, text: inout String, cursor: inout Int) {
-        cursor = min(max(0, cursor), text.count)
+    private func makeInputFieldPasteHandler(for node: Node) -> (String) -> Void {
+        return { [weak node] pastedText in
+            guard let node else { return }
+            var displayText = node[.displayText] ?? ""
+            var store = node[.pasteStore] ?? [:]
+            var cursor = min(max(0, node[.cursorPosition] ?? displayText.count), displayText.count)
+            let isSecure = node[.isSecure] == true
+
+            if isSecure || !PasteCollapse.shouldCollapse(pastedText) {
+                PasteCollapse.insertRaw(pastedText, into: &displayText, cursor: &cursor)
+            } else {
+                _ = PasteCollapse.insertCollapsedPaste(
+                    pastedText,
+                    into: &displayText,
+                    cursor: &cursor,
+                    store: &store
+                )
+            }
+
+            node[.displayText] = displayText
+            node[.pasteStore] = store
+            node[.cursorPosition] = cursor
+            NodeViewBuilder.syncBinding(from: node)
+            Application.shared?.scheduleUpdate()
+        }
+    }
+
+    private static func applyKeyEdit(
+        _ key: Key,
+        displayText: inout String,
+        cursor: inout Int,
+        store: inout [String: String]
+    ) {
+        cursor = min(max(0, cursor), displayText.count)
 
         switch key {
         case .char(let c):
-            let index = text.index(text.startIndex, offsetBy: cursor)
-            text.insert(c, at: index)
-            cursor += 1
+            PasteCollapse.insertRaw(String(c), into: &displayText, cursor: &cursor)
         case .backspace:
-            if cursor > 0 && !text.isEmpty {
-                let index = text.index(text.startIndex, offsetBy: cursor - 1)
-                text.remove(at: index)
-                cursor -= 1
-            }
+            PasteCollapse.backspace(displayText: &displayText, cursor: &cursor, store: &store)
         case .delete:
-            if cursor < text.count {
-                let index = text.index(text.startIndex, offsetBy: cursor)
-                text.remove(at: index)
-            }
+            PasteCollapse.deleteForward(displayText: &displayText, cursor: &cursor, store: &store)
         case .left:
-            cursor = max(0, cursor - 1)
+            PasteCollapse.moveLeft(cursor: &cursor, in: displayText)
         case .right:
-            cursor = min(text.count, cursor + 1)
+            PasteCollapse.moveRight(cursor: &cursor, in: displayText)
         case .home:
             cursor = 0
         case .end:
-            cursor = text.count
+            cursor = displayText.count
         default:
             break
         }
@@ -137,20 +193,22 @@ extension NodeViewBuilder {
     ) -> Void {
         return { [weak node] frame, buffer in
             guard let node = node else { return }
-            let text = node[.getText]?() ?? ""
+            let rawDisplay = node[.displayText] ?? ""
+            let store = node[.pasteStore] ?? [:]
             let placeholder = node[.placeholder] ?? ""
-            let displayText: String
+            let shown: String
 
-            if text.isEmpty {
-                displayText = placeholder
+            if rawDisplay.isEmpty {
+                shown = placeholder
             } else if isSecure {
-                displayText = String(repeating: "\u{2022}", count: text.count)
+                let expanded = PasteCollapse.expand(displayText: rawDisplay, store: store)
+                shown = String(repeating: "\u{2022}", count: expanded.count)
             } else {
-                displayText = text
+                shown = PasteCollapse.visualString(displayText: rawDisplay, store: store)
             }
 
             var style: Style
-            if text.isEmpty {
+            if rawDisplay.isEmpty {
                 style = Style().resolved(
                     with: node.environment,
                     fallbackForeground: .brightBlack
@@ -161,7 +219,7 @@ extension NodeViewBuilder {
             }
 
             buffer.drawClipped(
-                displayText,
+                shown,
                 at: frame.origin,
                 maxWidth: frame.width,
                 style: style,

--- a/Sources/Whisker/Rendering/TerminalTextWidth.swift
+++ b/Sources/Whisker/Rendering/TerminalTextWidth.swift
@@ -28,16 +28,18 @@ func terminalTextWidth(
 }
 
 func textInputCursorColumn(for node: Node) -> Int {
-    let text = node[.getText]?() ?? ""
+    let displayText = node[.displayText] ?? node[.getText]?() ?? ""
     let characterOffset = min(
-        max(0, node[.cursorPosition] ?? text.count),
-        text.count
+        max(0, node[.cursorPosition] ?? displayText.count),
+        displayText.count
     )
     if node[.isSecure] == true { return characterOffset }
 
-    let index = text.index(text.startIndex, offsetBy: characterOffset)
-    return terminalTextWidth(
-        text[..<index],
+    let store = node[.pasteStore] ?? [:]
+    return PasteCollapse.visualWidth(
+        displayText: displayText,
+        store: store,
+        upToCharacterOffset: characterOffset,
         replacingControlCharacters: true
     )
 }

--- a/Tests/WhiskerTests/PasteCollapseTests.swift
+++ b/Tests/WhiskerTests/PasteCollapseTests.swift
@@ -98,11 +98,26 @@ final class PasteCollapseTests: XCTestCase {
             store: &store
         )
         // cursor is after sentinel
-        PasteCollapse.moveLeft(cursor: &cursor, in: display)
+        PasteCollapse.moveLeft(cursor: &cursor, in: display, store: store)
         XCTAssertEqual(cursor, 1) // before sentinel (after "x")
 
-        PasteCollapse.moveRight(cursor: &cursor, in: display)
+        PasteCollapse.moveRight(cursor: &cursor, in: display, store: store)
         XCTAssertEqual(cursor, display.count)
+    }
+
+    func testSentinelShapedUserTextStaysLiteral() {
+        // User text that mimics a marker but has no store entry must survive
+        // expansion unchanged and never be treated as a paste reference.
+        let fake = "a\(PasteCollapse.makeSentinel(id: "deadbeef"))b"
+        let store: [String: String] = [:]
+
+        XCTAssertTrue(PasteCollapse.sentinelSpans(in: fake, store: store).isEmpty)
+        XCTAssertEqual(PasteCollapse.expand(displayText: fake, store: store), fake)
+        XCTAssertEqual(PasteCollapse.visualString(displayText: fake, store: store), fake)
+
+        var cursor = fake.count
+        PasteCollapse.moveLeft(cursor: &cursor, in: fake, store: store)
+        XCTAssertEqual(cursor, fake.count - 1) // one char, not the whole span
     }
 
     func testVisualWidthCountsLabelNotSentinel() {

--- a/Tests/WhiskerTests/PasteCollapseTests.swift
+++ b/Tests/WhiskerTests/PasteCollapseTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import Whisker
+
+final class PasteCollapseTests: XCTestCase {
+    func testWordCountSplitsOnWhitespace() {
+        XCTAssertEqual(PasteCollapse.wordCount(""), 0)
+        XCTAssertEqual(PasteCollapse.wordCount("  one  two\nthree\t"), 3)
+        XCTAssertEqual(PasteCollapse.wordCount("single"), 1)
+    }
+
+    func testShouldCollapseAtThreshold() {
+        let words = (1...50).map { "w\($0)" }.joined(separator: " ")
+        XCTAssertTrue(PasteCollapse.shouldCollapse(words))
+        XCTAssertFalse(PasteCollapse.shouldCollapse("short paste"))
+    }
+
+    func testLabelSingularAndPlural() {
+        XCTAssertEqual(PasteCollapse.label(forPayload: "hello"), "[Pasted 1 word]")
+        XCTAssertEqual(PasteCollapse.label(forPayload: "a b c"), "[Pasted 3 words]")
+    }
+
+    func testExpandAndVisualRoundTrip() {
+        var display = "hello "
+        var cursor = display.count
+        var store: [String: String] = [:]
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        _ = PasteCollapse.insertCollapsedPaste(
+            payload,
+            into: &display,
+            cursor: &cursor,
+            store: &store
+        )
+        display += " world"
+
+        XCTAssertEqual(
+            PasteCollapse.expand(displayText: display, store: store),
+            "hello \(payload) world"
+        )
+        XCTAssertEqual(
+            PasteCollapse.visualString(displayText: display, store: store),
+            "hello [Pasted 50 words] world"
+        )
+        XCTAssertEqual(store.count, 1)
+    }
+
+    func testAtomicBackspaceDeletesSentinel() {
+        var display = "ab"
+        var cursor = display.count
+        var store: [String: String] = [:]
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        _ = PasteCollapse.insertCollapsedPaste(
+            payload,
+            into: &display,
+            cursor: &cursor,
+            store: &store
+        )
+        display += "cd"
+        cursor = display.count - 2 // after sentinel, before "cd"
+
+        PasteCollapse.backspace(displayText: &display, cursor: &cursor, store: &store)
+
+        XCTAssertEqual(display, "abcd")
+        XCTAssertEqual(cursor, 2)
+        XCTAssertTrue(store.isEmpty)
+        XCTAssertEqual(PasteCollapse.expand(displayText: display, store: store), "abcd")
+    }
+
+    func testAtomicDeleteForwardRemovesSentinel() {
+        var display = "ab"
+        var cursor = display.count
+        var store: [String: String] = [:]
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        _ = PasteCollapse.insertCollapsedPaste(
+            payload,
+            into: &display,
+            cursor: &cursor,
+            store: &store
+        )
+        display += "cd"
+        cursor = 2 // at start of sentinel
+
+        PasteCollapse.deleteForward(displayText: &display, cursor: &cursor, store: &store)
+
+        XCTAssertEqual(display, "abcd")
+        XCTAssertEqual(cursor, 2)
+        XCTAssertTrue(store.isEmpty)
+    }
+
+    func testArrowKeysJumpOverSentinel() {
+        var display = "x"
+        var cursor = display.count
+        var store: [String: String] = [:]
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        _ = PasteCollapse.insertCollapsedPaste(
+            payload,
+            into: &display,
+            cursor: &cursor,
+            store: &store
+        )
+        // cursor is after sentinel
+        PasteCollapse.moveLeft(cursor: &cursor, in: display)
+        XCTAssertEqual(cursor, 1) // before sentinel (after "x")
+
+        PasteCollapse.moveRight(cursor: &cursor, in: display)
+        XCTAssertEqual(cursor, display.count)
+    }
+
+    func testVisualWidthCountsLabelNotSentinel() {
+        var display = "hi "
+        var cursor = display.count
+        var store: [String: String] = [:]
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        _ = PasteCollapse.insertCollapsedPaste(
+            payload,
+            into: &display,
+            cursor: &cursor,
+            store: &store
+        )
+
+        let expected = terminalTextWidth("hi [Pasted 50 words]", replacingControlCharacters: true)
+        let actual = PasteCollapse.visualWidth(
+            displayText: display,
+            store: store,
+            upToCharacterOffset: display.count
+        )
+        XCTAssertEqual(actual, expected)
+    }
+}

--- a/Tests/WhiskerTests/WhiskerIntegrationTests.swift
+++ b/Tests/WhiskerTests/WhiskerIntegrationTests.swift
@@ -236,4 +236,179 @@ final class WhiskerIntegrationTests: XCTestCase {
 
         XCTAssertEqual(buffer.commands.map(\.cell.char), ["a", " ", " ", "b"])
     }
+
+    func testLargePasteCollapsesInRenderButExpandsBinding() {
+        var text = ""
+        let node = Node(viewType: TextField.self)
+        let viewBuilder = NodeViewBuilder()
+        viewBuilder.buildInputFieldNode(
+            node,
+            getText: { text },
+            setText: { text = $0 },
+            placeholder: "",
+            isSecure: false
+        )
+
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        node[.pasteInputHandler]?(payload)
+
+        XCTAssertEqual(text, payload)
+        XCTAssertNotEqual(node[.displayText], payload)
+        XCTAssertEqual(
+            PasteCollapse.visualString(
+                displayText: node[.displayText] ?? "",
+                store: node[.pasteStore] ?? [:]
+            ),
+            "[Pasted 50 words]"
+        )
+
+        node.frame = Rect(x: 0, y: 0, width: 40, height: 1)
+        var buffer = RenderBuffer()
+        node.render?(node.frame, &buffer)
+        let rendered = String(buffer.commands.map(\.cell.char))
+        XCTAssertTrue(rendered.contains("[Pasted 50 words]"))
+        XCTAssertFalse(rendered.contains("w1"))
+    }
+
+    func testSmallPasteInsertsInline() {
+        var text = "x"
+        let node = Node(viewType: TextField.self)
+        let viewBuilder = NodeViewBuilder()
+        viewBuilder.buildInputFieldNode(
+            node,
+            getText: { text },
+            setText: { text = $0 },
+            placeholder: "",
+            isSecure: false
+        )
+        node[.cursorPosition] = 1
+        node[.pasteInputHandler]?("yes")
+
+        XCTAssertEqual(text, "xyes")
+        XCTAssertEqual(node[.displayText], "xyes")
+        XCTAssertTrue((node[.pasteStore] ?? [:]).isEmpty)
+    }
+
+    func testSecureFieldDoesNotCollapseLargePaste() {
+        var text = ""
+        let node = Node(viewType: SecureField.self)
+        let viewBuilder = NodeViewBuilder()
+        viewBuilder.buildInputFieldNode(
+            node,
+            getText: { text },
+            setText: { text = $0 },
+            placeholder: "",
+            isSecure: true
+        )
+
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        node[.pasteInputHandler]?(payload)
+
+        XCTAssertEqual(text, payload)
+        XCTAssertEqual(node[.displayText], payload)
+        XCTAssertTrue((node[.pasteStore] ?? [:]).isEmpty)
+    }
+
+    func testRebuildPreservesMarkersWhenBindingUnchanged() {
+        var text = ""
+        let viewBuilder = NodeViewBuilder()
+        let first = Node(viewType: TextField.self)
+        viewBuilder.buildInputFieldNode(
+            first,
+            getText: { text },
+            setText: { text = $0 },
+            placeholder: "",
+            isSecure: false
+        )
+
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        first[.pasteInputHandler]?(payload)
+        let displayBefore = first[.displayText]
+        let storeBefore = first[.pasteStore]
+
+        let second = Node(viewType: TextField.self)
+        viewBuilder.buildInputFieldNode(
+            second,
+            getText: { text },
+            setText: { text = $0 },
+            placeholder: "",
+            isSecure: false,
+            existing: first
+        )
+
+        XCTAssertEqual(second[.displayText], displayBefore)
+        XCTAssertEqual(second[.pasteStore], storeBefore)
+        XCTAssertEqual(text, payload)
+    }
+
+    func testExternalBindingChangeClearsMarkers() {
+        var text = ""
+        let viewBuilder = NodeViewBuilder()
+        let first = Node(viewType: TextField.self)
+        viewBuilder.buildInputFieldNode(
+            first,
+            getText: { text },
+            setText: { text = $0 },
+            placeholder: "",
+            isSecure: false
+        )
+
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        first[.pasteInputHandler]?(payload)
+
+        text = "replaced externally"
+        let second = Node(viewType: TextField.self)
+        viewBuilder.buildInputFieldNode(
+            second,
+            getText: { text },
+            setText: { text = $0 },
+            placeholder: "",
+            isSecure: false,
+            existing: first
+        )
+
+        XCTAssertEqual(second[.displayText], "replaced externally")
+        XCTAssertTrue((second[.pasteStore] ?? [:]).isEmpty)
+    }
+
+    func testCursorColumnAfterCollapsedPasteUsesLabelWidth() {
+        var text = "hi "
+        let node = Node(viewType: TextField.self)
+        let viewBuilder = NodeViewBuilder()
+        viewBuilder.buildInputFieldNode(
+            node,
+            getText: { text },
+            setText: { text = $0 },
+            placeholder: "",
+            isSecure: false
+        )
+        node[.cursorPosition] = 3
+
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        node[.pasteInputHandler]?(payload)
+
+        let expected = terminalTextWidth("hi [Pasted 50 words]", replacingControlCharacters: true)
+        XCTAssertEqual(textInputCursorColumn(for: node), expected)
+    }
+
+    func testAtomicBackspaceRemovesCollapsedPasteFromField() {
+        var text = ""
+        let node = Node(viewType: TextField.self)
+        let viewBuilder = NodeViewBuilder()
+        viewBuilder.buildInputFieldNode(
+            node,
+            getText: { text },
+            setText: { text = $0 },
+            placeholder: "",
+            isSecure: false
+        )
+
+        let payload = (1...50).map { "w\($0)" }.joined(separator: " ")
+        node[.pasteInputHandler]?(payload)
+        node[.keyHandler]?(KeyEvent(key: .backspace))
+
+        XCTAssertEqual(text, "")
+        XCTAssertEqual(node[.displayText], "")
+        XCTAssertTrue((node[.pasteStore] ?? [:]).isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- Collapse bracketed pastes of 50+ words into atomic `[Pasted N words]` markers in TextField while keeping `@Binding` always expanded to the full payload
- Treat markers as single edit units for left/right/backspace/delete; SecureField never collapses
- Add `PasteCollapse` helper plus unit and integration coverage for expand/visual, rebuild reconciliation, and cursor width

## Test plan
- [ ] `swift test` passes
- [ ] `swift run Examples`, paste 50+ words into Name → field shows `[Pasted N words]`
- [ ] Paste a short phrase → inserts inline
- [ ] Backspace after a collapsed paste removes the whole marker
- [ ] Confirm submit / binding still contains the full expanded text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Large pastes in input fields now collapse into a compact “[Pasted N words]” placeholder while retaining the full text for the bound value.
  - Paste-aware editing: improved atomic cursor navigation and deletion/insertion behavior for collapsed paste regions.
  - Secure fields continue pasting without collapsing, preserving secure rendering.

- **Bug Fixes**
  - Cursor positioning and measured visual width now align with the placeholder rendering.
  - Paste placeholders are preserved across rebuilds and cleared when the underlying text changes.

- **Tests**
  - Added unit and integration coverage for paste collapsing, rendering, cursor/edit behavior, and secure-field paste handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->