### PR TITLE
feat: add SelectList, a vertical picker control

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full deep-dive.
 | `TextField` | Single-line text input |
 | `SecureField` | Masked password input |
 | `Button` | Pressable control with label and action |
+| `SelectList` | Vertical option list: arrow keys move the selection, `onSubmit`/`onCancel` report enter and escape, and a sliding window keeps long lists within `visibleRows` |
+
+At either end of a `SelectList` an arrow key hands focus to the next control
+rather than doing nothing, so the list is never a keyboard trap — pass
+`wraps: true` to cycle within it instead.
 
 Custom views can participate in key handling too: `.focusable()` adds any view
 to the focus ring, and `.onKeyPress { event in ... }` (composable with

--- a/Sources/Examples/main.swift
+++ b/Sources/Examples/main.swift
@@ -24,9 +24,19 @@ struct FormView: View {
     @State var password = ""
     @State var confirmPassword = ""
     @State var planIndex = 0
+    @State var planFilter = ""
+    @State var favoriteIndex = 0
+    @State var favorite = ""
     @State var message = ""
     @State var messageColor: Color = .white
     @State var phase: Int = 0
+
+    /// The picker half of the demo: the "Favorite?" field narrows this list,
+    /// and the SelectList below it clamps its selection as the options shrink.
+    var filteredPlans: [String] {
+        guard !planFilter.isEmpty else { return plans }
+        return plans.filter { $0.lowercased().contains(planFilter.lowercased()) }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -64,6 +74,28 @@ struct FormView: View {
                     overflow: .wrap
                 )
                 .foregroundColor(.brightCyan)
+            }
+            HStack(spacing: 0) {
+                Text("? ").foregroundColor(.brightYellow)
+                Text("Favorite? ").bold()
+                Text("› ").foregroundColor(.brightBlack)
+                TextField("Type to filter, tab to the list", text: $planFilter)
+            }
+            HStack(spacing: 0) {
+                Text("  ")
+                SelectList(
+                    filteredPlans,
+                    selection: $favoriteIndex,
+                    visibleRows: 6,
+                    onSubmit: { index in
+                        guard index < filteredPlans.count else { return }
+                        favorite = filteredPlans[index]
+                    },
+                    onCancel: { planFilter = "" }
+                )
+            }
+            if !favorite.isEmpty {
+                Text("  ★ \(favorite)").foregroundColor(.brightYellow)
             }
             if phase == 0 {
                 HStack(spacing: 0) {

--- a/Sources/Whisker/Core/ViewBuilder+Controls.swift
+++ b/Sources/Whisker/Core/ViewBuilder+Controls.swift
@@ -17,6 +17,9 @@ extension NodeViewBuilder {
         } else if let segmented = view as? SegmentedControl {
             buildSegmentedControlNode(node, segmented: segmented)
             return true
+        } else if let selectList = view as? SelectList {
+            buildSelectListNode(node, selectList: selectList)
+            return true
         }
         return false
     }

--- a/Sources/Whisker/Core/ViewBuilder+SelectList.swift
+++ b/Sources/Whisker/Core/ViewBuilder+SelectList.swift
@@ -21,7 +21,9 @@ extension NodeViewBuilder {
 
         node.layout = { proposal, _ in
             let window = selectList.window()
-            let widest = selectList.options.reduce(0) { max($0, $1.count) }
+            let widest = selectList.options.reduce(0) {
+                max($0, terminalTextWidth($1, replacingControlCharacters: true))
+            }
             // Two columns for the pointer gutter, so rows line up whether or
             // not they are the selected one.
             let contentWidth = widest + 2

--- a/Sources/Whisker/Core/ViewBuilder+SelectList.swift
+++ b/Sources/Whisker/Core/ViewBuilder+SelectList.swift
@@ -1,0 +1,139 @@
+// MARK: - Select List
+
+extension NodeViewBuilder {
+
+    func buildSelectListNode(_ node: Node, selectList: SelectList) {
+        // An empty list has nothing to select, so it stays out of the focus
+        // ring rather than becoming a stop that swallows keys and shows nothing.
+        node.isFocusable = !selectList.options.isEmpty
+        node[.keyHandler] = makeSelectListKeyHandler(for: selectList)
+
+        node.render = { [weak node] frame, buffer in
+            guard let node = node else { return }
+            NodeViewBuilder.renderSelectList(
+                selectList,
+                isFocused: node.isFocused,
+                baseStyle: Style().resolved(with: node.environment),
+                frame: frame,
+                buffer: &buffer
+            )
+        }
+
+        node.layout = { proposal, _ in
+            let window = selectList.window()
+            let widest = selectList.options.reduce(0) { max($0, $1.count) }
+            // Two columns for the pointer gutter, so rows line up whether or
+            // not they are the selected one.
+            let contentWidth = widest + 2
+            return (
+                Size(
+                    width: proposal.width.resolve(with: contentWidth),
+                    height: max(window.height, 1)
+                ), []
+            )
+        }
+    }
+
+    private func makeSelectListKeyHandler(for selectList: SelectList) -> (KeyEvent) -> Bool {
+        return { (event: KeyEvent) in
+            guard !selectList.options.isEmpty else { return false }
+
+            switch event.key {
+            case .up, .down:
+                guard let next = NodeViewBuilder.movedSelection(selectList, key: event.key) else {
+                    return false
+                }
+                if next != selectList.selection.wrappedValue {
+                    selectList.selection.wrappedValue = next
+                    Application.shared?.scheduleUpdate()
+                }
+                return true
+            case .enter:
+                guard let onSubmit = selectList.onSubmit else { return false }
+                onSubmit(selectList.clampedSelection)
+                return true
+            case .escape:
+                guard let onCancel = selectList.onCancel else { return false }
+                onCancel()
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    /// Where an arrow key moves the selection, or `nil` when the list declines
+    /// the key at a boundary.
+    ///
+    /// Declining is what keeps the list out of the way: `handleKey` falls back
+    /// to focus traversal, so an arrow at the end of the list moves on to the
+    /// next control instead of being swallowed.
+    private static func movedSelection(_ selectList: SelectList, key: Key) -> Int? {
+        let current = selectList.clampedSelection
+        let last = selectList.options.count - 1
+
+        switch key {
+        case .up:
+            if current > 0 { return current - 1 }
+            return selectList.wraps ? last : nil
+        case .down:
+            if current < last { return current + 1 }
+            return selectList.wraps ? 0 : nil
+        default:
+            return nil
+        }
+    }
+
+    // MARK: Rendering
+
+    private static func renderSelectList(
+        _ selectList: SelectList,
+        isFocused: Bool,
+        baseStyle: Style,
+        frame: Rect,
+        buffer: inout RenderBuffer
+    ) {
+        guard frame.width > 0, frame.height > 0, !selectList.options.isEmpty else { return }
+
+        let window = selectList.window()
+        let selected = selectList.clampedSelection
+        let markerStyle = Style(foreground: .brightBlack)
+        var row = frame.y
+        let bottom = frame.y + frame.height
+
+        func drawRow(_ text: String, style: Style) {
+            guard row < bottom else { return }
+            buffer.drawClipped(
+                text, at: Position(x: frame.x, y: row), maxWidth: frame.width, style: style)
+            row += 1
+        }
+
+        if window.showsMarkers {
+            drawRow(window.hasMoreAbove ? "\u{25B2}" : " ", style: markerStyle)
+        }
+
+        for index in window.range {
+            let isSelected = index == selected
+            // The pointer only appears while focused, so an unfocused list
+            // still shows what is selected without implying the arrow keys
+            // are currently going to it.
+            let prefix = isSelected && isFocused ? "\u{276F} " : "  "
+            drawRow(prefix + selectList.options[index], style: rowStyle(
+                baseStyle, isSelected: isSelected, isFocused: isFocused))
+        }
+
+        if window.showsMarkers {
+            drawRow(window.hasMoreBelow ? "\u{25BC}" : " ", style: markerStyle)
+        }
+    }
+
+    /// Selected rows invert; focus adds bold on top, matching `SegmentedControl`.
+    private static func rowStyle(_ base: Style, isSelected: Bool, isFocused: Bool) -> Style {
+        var style = base
+        if isSelected {
+            style.attributes.insert(.reverse)
+            if isFocused { style.attributes.insert(.bold) }
+        }
+        return style
+    }
+}

--- a/Sources/Whisker/Views/Controls/SelectList.swift
+++ b/Sources/Whisker/Views/Controls/SelectList.swift
@@ -1,0 +1,109 @@
+/// A vertical list of options that lets you move a selection with the arrow keys.
+///
+/// The list joins the focus ring like any other control. While focused, `.up`
+/// and `.down` move the selection; `.enter` submits it and `.escape` cancels,
+/// each only when the matching handler was supplied. When there are more
+/// options than `visibleRows`, a sliding window keeps the selection in view
+/// with `▲`/`▼` overflow markers, and the list never occupies more than
+/// `visibleRows` lines — important in inline mode, which has no viewport
+/// clipping.
+///
+/// At the ends of the list an arrow key moves focus onward instead of doing
+/// nothing, so the list never traps someone navigating by keyboard. Set
+/// `wraps` to cycle within the list instead.
+///
+///     SelectList(
+///         repos,
+///         selection: $index,
+///         onSubmit: { picked = repos[$0]; Application.shared?.quit() },
+///         onCancel: { Application.shared?.quit() }
+///     )
+public struct SelectList: View {
+    public typealias Body = Never
+
+    let options: [String]
+    let selection: Binding<Int>
+    let wraps: Bool
+    let visibleRows: Int
+    let onSubmit: ((Int) -> Void)?
+    let onCancel: (() -> Void)?
+
+    /// Create a select list with string options and an index binding.
+    ///
+    /// - Parameters:
+    ///   - options: The rows to choose between.
+    ///   - selection: The selected index. Out-of-range values — after the
+    ///     options array shrinks, say — are clamped rather than trapping.
+    ///   - wraps: Whether the selection cycles at the ends instead of handing
+    ///     focus onward, like `SegmentedControl`'s `wraps`.
+    ///   - visibleRows: The most terminal rows the list may occupy.
+    ///   - onSubmit: Called with the selected index when `.enter` is pressed.
+    ///     Without it `.enter` is left to the surrounding view.
+    ///   - onCancel: Called when `.escape` is pressed. Without it `.escape` is
+    ///     left to the surrounding view.
+    public init(
+        _ options: [String],
+        selection: Binding<Int>,
+        wraps: Bool = false,
+        visibleRows: Int = 10,
+        onSubmit: ((Int) -> Void)? = nil,
+        onCancel: (() -> Void)? = nil
+    ) {
+        self.options = options
+        self.selection = selection
+        self.wraps = wraps
+        self.visibleRows = max(1, visibleRows)
+        self.onSubmit = onSubmit
+        self.onCancel = onCancel
+    }
+
+    public var body: Never {
+        fatalError("SelectList has no body")
+    }
+
+    // MARK: - Windowing
+
+    /// The slice of options on screen, and whether more sit above or below.
+    struct Window {
+        let range: Range<Int>
+        let showsMarkers: Bool
+        let hasMoreAbove: Bool
+        let hasMoreBelow: Bool
+
+        /// Rows occupied on screen, never more than the list's `visibleRows`.
+        var height: Int { range.count + (showsMarkers ? 2 : 0) }
+    }
+
+    var clampedSelection: Int {
+        guard !options.isEmpty else { return 0 }
+        return min(max(selection.wrappedValue, 0), options.count - 1)
+    }
+
+    /// Derive the visible window from the selection alone — no stored scroll
+    /// offset — so it behaves the same travelling up as down. The selection
+    /// stays centred except near the ends. Markers cost a row each, so they
+    /// are only drawn when `visibleRows` can spare them.
+    func window() -> Window {
+        guard !options.isEmpty else {
+            return Window(
+                range: 0..<0, showsMarkers: false, hasMoreAbove: false, hasMoreBelow: false)
+        }
+
+        let count = options.count
+        guard count > visibleRows else {
+            return Window(
+                range: 0..<count, showsMarkers: false, hasMoreAbove: false, hasMoreBelow: false)
+        }
+
+        let showsMarkers = visibleRows >= 3
+        let size = showsMarkers ? visibleRows - 2 : visibleRows
+        let offset = min(max(0, clampedSelection - size / 2), count - size)
+
+        return Window(
+            range: offset..<(offset + size),
+            showsMarkers: showsMarkers,
+            hasMoreAbove: offset > 0,
+            hasMoreBelow: offset + size < count
+        )
+    }
+}

--- a/Tests/WhiskerTests/SelectListTests.swift
+++ b/Tests/WhiskerTests/SelectListTests.swift
@@ -342,6 +342,19 @@ final class SelectListTests: XCTestCase {
         XCTAssertEqual(submitted, 0, "A stale index is clamped into range")
     }
 
+    func testWideOptionsAreMeasuredInTerminalCells() {
+        // "猫猫" is two characters but four terminal cells, so a width taken
+        // from String.count would clip the row.
+        let selectList = SelectList(["ab", "\u{732B}\u{732B}"], selection: .constant(0))
+        let node = NodeViewBuilder().buildNode(from: selectList)
+
+        let (size, _) = node.layout!(
+            ProposedSize(width: .unconstrained, height: .unconstrained), node.children)
+
+        // Four cells for the widest option plus the two-column pointer gutter.
+        XCTAssertEqual(size.width, 6)
+    }
+
     func testOverflowMarkersAreDrawn() {
         let backend = TestBackend(size: Size(width: 30, height: 10))
         let options = (1...20).map { "option-\($0)" }

--- a/Tests/WhiskerTests/SelectListTests.swift
+++ b/Tests/WhiskerTests/SelectListTests.swift
@@ -1,0 +1,361 @@
+import XCTest
+
+@testable import Whisker
+
+final class SelectListTests: XCTestCase {
+
+    private func makeApp(
+        backend: TestBackend = TestBackend(size: Size(width: 30, height: 20)),
+        @ViewBuilder rootView: @escaping () -> some View
+    ) -> Application {
+        Application(mode: .fullscreen, backend: backend, rootView: rootView)
+    }
+
+    override func tearDown() {
+        Application.shared = nil
+        NodeContext.current = nil
+        super.tearDown()
+    }
+
+    // MARK: - Selection movement
+
+    func testArrowsMoveSelection() {
+        var choice = 0
+        let app = makeApp {
+            SelectList(
+                ["alpha", "beta", "gamma"],
+                selection: Binding(get: { choice }, set: { choice = $0 }))
+        }
+        app.rebuild()
+
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .down)))
+        XCTAssertEqual(choice, 1)
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .down)))
+        XCTAssertEqual(choice, 2)
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .up)))
+        XCTAssertEqual(choice, 1)
+    }
+
+    // MARK: - Boundaries hand focus onward
+
+    func testDownAtBottomReleasesFocusInsteadOfTrapping() {
+        var choice = 1
+        var text = ""
+        let app = makeApp {
+            VStack {
+                SelectList(
+                    ["alpha", "beta"],
+                    selection: Binding(get: { choice }, set: { choice = $0 }))
+                TextField("after", get: { text }, set: { text = $0 })
+            }
+        }
+        app.rebuild()
+        XCTAssertEqual(app.focusedIndex, 0, "The list starts focused")
+
+        // Selection is already on the last row, so .down has nowhere to go
+        // inside the list and must fall through to focus traversal.
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .down)))
+        XCTAssertEqual(choice, 1, "Selection stays put at the boundary")
+        XCTAssertEqual(app.focusedIndex, 1, "Focus moves on to the next control")
+    }
+
+    func testUpAtTopReleasesFocusInsteadOfTrapping() {
+        var choice = 0
+        var text = ""
+        let app = makeApp {
+            VStack {
+                TextField("before", get: { text }, set: { text = $0 })
+                SelectList(
+                    ["alpha", "beta"],
+                    selection: Binding(get: { choice }, set: { choice = $0 }))
+            }
+        }
+        app.rebuild()
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .tab)))
+        XCTAssertEqual(app.focusedIndex, 1, "Focus starts on the list")
+
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .up)))
+        XCTAssertEqual(choice, 0, "Selection stays put at the boundary")
+        XCTAssertEqual(app.focusedIndex, 0, "Focus moves back to the field above")
+    }
+
+    func testWrapsCyclesAndKeepsFocus() {
+        var choice = 2
+        var text = ""
+        let app = makeApp {
+            VStack {
+                SelectList(
+                    ["alpha", "beta", "gamma"],
+                    selection: Binding(get: { choice }, set: { choice = $0 }),
+                    wraps: true)
+                TextField("after", get: { text }, set: { text = $0 })
+            }
+        }
+        app.rebuild()
+
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .down)))
+        XCTAssertEqual(choice, 0, "Wrapping list cycles to the top")
+        XCTAssertEqual(app.focusedIndex, 0, "A wrapping list keeps focus at the boundary")
+
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .up)))
+        XCTAssertEqual(choice, 2, "Wrapping list cycles to the bottom")
+        XCTAssertEqual(app.focusedIndex, 0)
+    }
+
+    // MARK: - Submit and cancel
+
+    func testEnterSubmitsSelectedIndex() {
+        var choice = 0
+        var submitted: Int?
+        let app = makeApp {
+            SelectList(
+                ["alpha", "beta", "gamma"],
+                selection: Binding(get: { choice }, set: { choice = $0 }),
+                onSubmit: { submitted = $0 })
+        }
+        app.rebuild()
+
+        _ = app.handleKey(KeyEvent(key: .down))
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .enter)))
+        XCTAssertEqual(submitted, 1, "Enter reports the selected index")
+    }
+
+    func testEscapeCancels() {
+        var choice = 0
+        var cancelled = false
+        let app = makeApp {
+            SelectList(
+                ["alpha", "beta"],
+                selection: Binding(get: { choice }, set: { choice = $0 }),
+                onCancel: { cancelled = true })
+        }
+        app.rebuild()
+
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .escape)))
+        XCTAssertTrue(cancelled)
+    }
+
+    func testEnterWithoutHandlerIsLeftToTheSurroundingView() {
+        var choice = 0
+        var pressed = false
+        let app = makeApp {
+            VStack {
+                SelectList(
+                    ["alpha", "beta"],
+                    selection: Binding(get: { choice }, set: { choice = $0 }))
+                Button("ok") { pressed = true }
+            }
+            .onKeyPress { event in
+                if event.key == .enter {
+                    pressed = true
+                    return .handled
+                }
+                return .ignored
+            }
+        }
+        app.rebuild()
+
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .enter)))
+        XCTAssertTrue(pressed, "An unhandled .enter should bubble to the ancestor handler")
+    }
+
+    // MARK: - Degenerate inputs
+
+    func testEmptyOptionsStayOutOfTheFocusRing() {
+        var choice = 0
+        let app = makeApp {
+            VStack {
+                SelectList([], selection: Binding(get: { choice }, set: { choice = $0 }))
+                Button("ok") {}
+            }
+        }
+        app.rebuild()
+
+        let ring = FocusManager.allFocusableNodes(root: app.rootNode)
+        XCTAssertEqual(ring.count, 1, "An empty list is not a focus stop")
+    }
+
+    func testSelectionBeyondOptionsIsClamped() {
+        var choice = 99
+        let app = makeApp {
+            SelectList(
+                ["alpha", "beta"], selection: Binding(get: { choice }, set: { choice = $0 }))
+        }
+        app.rebuild()
+
+        // Clamped to the last row, so .up lands on the row above it.
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .up)))
+        XCTAssertEqual(choice, 0)
+    }
+
+    // MARK: - Windowing
+
+    func testWindowNeverExceedsVisibleRows() {
+        let options = (1...20).map { "option-\($0)" }
+        for visibleRows in 1...6 {
+            let list = SelectList(options, selection: .constant(10), visibleRows: visibleRows)
+            XCTAssertLessThanOrEqual(
+                list.window().height, visibleRows,
+                "A list with visibleRows=\(visibleRows) must not draw more rows than that")
+        }
+    }
+
+    func testWindowKeepsSelectionVisibleAndReportsOverflow() {
+        let options = (1...20).map { "option-\($0)" }
+
+        let atTop = SelectList(options, selection: .constant(0), visibleRows: 6).window()
+        XCTAssertTrue(atTop.range.contains(0))
+        XCTAssertFalse(atTop.hasMoreAbove, "Nothing above the first row")
+        XCTAssertTrue(atTop.hasMoreBelow)
+
+        let inMiddle = SelectList(options, selection: .constant(10), visibleRows: 6).window()
+        XCTAssertTrue(inMiddle.range.contains(10))
+        XCTAssertTrue(inMiddle.hasMoreAbove)
+        XCTAssertTrue(inMiddle.hasMoreBelow)
+
+        let atBottom = SelectList(options, selection: .constant(19), visibleRows: 6).window()
+        XCTAssertTrue(atBottom.range.contains(19))
+        XCTAssertTrue(atBottom.hasMoreAbove)
+        XCTAssertFalse(atBottom.hasMoreBelow, "Nothing below the last row")
+    }
+
+    func testShortListShowsEveryOptionWithoutMarkers() {
+        let window = SelectList(["a", "b"], selection: .constant(0), visibleRows: 10).window()
+        XCTAssertEqual(window.range, 0..<2)
+        XCTAssertFalse(window.showsMarkers)
+        XCTAssertEqual(window.height, 2)
+    }
+
+    // MARK: - Rendering
+
+    func testFocusedListMarksSelectionWithPointerAndBold() {
+        let backend = TestBackend(size: Size(width: 30, height: 10))
+        var choice = 1
+        let app = makeApp(backend: backend) {
+            SelectList(
+                ["alpha", "beta"], selection: Binding(get: { choice }, set: { choice = $0 }))
+        }
+        app.rebuild()
+        app.render()
+
+        XCTAssertTrue(backend.text(atLine: 1).contains("\u{276F} beta"), "Selected row is pointed at")
+        let cell = backend.cell(at: Position(x: 0, y: 1))
+        XCTAssertTrue(cell?.style.attributes.contains(.reverse) ?? false)
+        XCTAssertTrue(
+            cell?.style.attributes.contains(.bold) ?? false, "Focused selection is bold")
+    }
+
+    func testUnfocusedListDropsThePointerAndBold() {
+        let backend = TestBackend(size: Size(width: 30, height: 10))
+        var choice = 1
+        var text = ""
+        let app = makeApp(backend: backend) {
+            // Leading alignment so the rows start at x = 0 and the styled
+            // cells are at known positions.
+            VStack(alignment: .leading) {
+                TextField("filter", get: { text }, set: { text = $0 })
+                SelectList(
+                    ["alpha", "beta"], selection: Binding(get: { choice }, set: { choice = $0 }))
+            }
+        }
+        app.rebuild()
+        app.render()
+        XCTAssertEqual(app.focusedIndex, 0, "Focus is on the field, not the list")
+
+        let selectedLine = backend.text(atLine: 2)
+        XCTAssertTrue(selectedLine.contains("beta"))
+        XCTAssertFalse(
+            selectedLine.contains("\u{276F}"),
+            "An unfocused list must not imply the arrows are going to it")
+
+        let cell = backend.cell(at: Position(x: 0, y: 2))
+        XCTAssertTrue(
+            cell?.style.attributes.contains(.reverse) ?? false,
+            "The selection is still visible when unfocused")
+        XCTAssertFalse(
+            cell?.style.attributes.contains(.bold) ?? false,
+            "Bold is reserved for the focused list")
+    }
+
+    // MARK: - The whole picker flow
+
+    func testFilterThenTabThenSubmitPicksTheFilteredOption() {
+        let all = ["cbx", "whisker", "stele", "whiskey"]
+        var filter = ""
+        var index = 0
+        var picked: String?
+
+        let app = makeApp {
+            VStack(alignment: .leading) {
+                TextField("filter", get: { filter }, set: { filter = $0 })
+                SelectList(
+                    all.filter { filter.isEmpty || $0.contains(filter) },
+                    selection: Binding(get: { index }, set: { index = $0 }),
+                    onSubmit: { picked = all.filter { filter.isEmpty || $0.contains(filter) }[$0] },
+                    onCancel: { picked = nil })
+            }
+        }
+        app.rebuild()
+
+        // Type into the filter: "whisk" leaves whisker and whiskey.
+        for character in "whisk" {
+            XCTAssertTrue(app.handleKey(KeyEvent(key: .char(character))))
+        }
+        XCTAssertEqual(filter, "whisk")
+
+        // Tab to the list, move down to the second match, submit.
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .tab)))
+        app.rebuild()
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .down)))
+        XCTAssertTrue(app.handleKey(KeyEvent(key: .enter)))
+
+        XCTAssertEqual(picked, "whiskey", "Enter should report the filtered option under the cursor")
+    }
+
+    func testSelectionStaysValidWhenTheFilterShrinksTheOptions() {
+        var options = ["alpha", "beta", "gamma"]
+        var choice = 0
+        let app = makeApp {
+            SelectList(options, selection: Binding(get: { choice }, set: { choice = $0 }))
+        }
+        app.rebuild()
+
+        _ = app.handleKey(KeyEvent(key: .down))
+        _ = app.handleKey(KeyEvent(key: .down))
+        XCTAssertEqual(choice, 2)
+
+        // The filter narrows the list out from under the selection.
+        options = ["alpha"]
+        app.rebuild()
+        app.render()
+
+        // Clamped, so .enter reports a valid index rather than trapping.
+        var submitted: Int?
+        let submitApp = makeApp {
+            SelectList(
+                options,
+                selection: Binding(get: { choice }, set: { choice = $0 }),
+                onSubmit: { submitted = $0 })
+        }
+        submitApp.rebuild()
+        XCTAssertTrue(submitApp.handleKey(KeyEvent(key: .enter)))
+        XCTAssertEqual(submitted, 0, "A stale index is clamped into range")
+    }
+
+    func testOverflowMarkersAreDrawn() {
+        let backend = TestBackend(size: Size(width: 30, height: 10))
+        let options = (1...20).map { "option-\($0)" }
+        var choice = 10
+        let app = makeApp(backend: backend) {
+            SelectList(
+                options,
+                selection: Binding(get: { choice }, set: { choice = $0 }),
+                visibleRows: 5)
+        }
+        app.rebuild()
+        app.render()
+
+        XCTAssertTrue(backend.text(atLine: 0).contains("\u{25B2}"), "More above is marked")
+        XCTAssertTrue(backend.text(atLine: 4).contains("\u{25BC}"), "More below is marked")
+    }
+}


### PR DESCRIPTION
Follows #23, which added the key-event API this builds on. `SelectList` was originally developed on that branch and pulled back out because, as written, it did not work as a picker. This is the rewrite.

## What it does

```swift
SelectList(
    repos,
    selection: $index,
    wraps: false,
    visibleRows: 10,
    onSubmit: { picked = repos[$0]; Application.shared?.quit() },
    onCancel: { Application.shared?.quit() }
)
```

Arrow keys move the selection, enter submits it, escape cancels. When there are more options than `visibleRows`, a sliding window keeps the selection in view with `▲`/`▼` markers and holds the list to `visibleRows` lines — inline mode has no viewport clipping, so an overlong view corrupts the redraw rather than scrolling.

## The four problems with the first draft

**Enter did nothing.** The control only handled `.up`/`.down`, so there was no way to confirm a choice — the binding tracked a highlight and that was all. `onSubmit` now reports the selected index. Without a handler the key is declined rather than swallowed, so a surrounding view can act on it.

**Escape did nothing.** Same shape, same fix via `onCancel`.

**Arrows trapped focus.** The handler consumed up/down even at the ends of the list, so once focus arrived it could never leave by arrow key — Tab was the only way out, which nobody guesses mid-form. A non-wrapping list now declines an arrow at its boundary and `handleKey` falls back to focus traversal, moving to the next control. `wraps: true` cycles within the list instead, and keeps focus.

**No focus cue.** The list rendered identically whether or not it had focus, so there was no way to tell that the arrow keys now belonged to it. Selected rows invert either way; focus additionally adds bold and the `❯` pointer. This follows `SegmentedControl`, which already inverts the selection and adds bold only when focused.

## Implementation note

Built as a control node (`ViewBuilder+SelectList.swift`) rather than composed from the public `.focusable()`/`.onKeyPress` modifiers, which is how the first draft did it. Rendering has to vary with focus, and `node.isFocused` is the only way to read that — there is no public equivalent. If focus state ever becomes public, this is worth revisiting, since composing it from public API was a nice proof that the modifiers are sufficient.

Windowing is stateless: the visible range is derived from the selection alone, keeping it centred except near the ends, so scrolling behaves the same travelling up as down. There is no stored scroll offset to fall out of sync with a selection that changed underneath it.

## Tests

122 passing, `swiftlint` clean with no new warnings. Coverage: arrow movement; boundary release in both directions and the wrapping alternative; submit and cancel, including the decline-when-unhandled path bubbling to an ancestor `.onKeyPress`; empty options staying out of the focus ring; out-of-range selections clamping; the window never exceeding `visibleRows` for every size from 1 to 6; overflow flags and markers at the top, middle and bottom; focused versus unfocused rendering; and the full picker flow — type a filter, tab to the list, arrow down, submit the right option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QxRKtDjNrsXEBG5GWrZoT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a selectable list control with keyboard navigation, optional wrapping, configurable visible rows, scrolling indicators, and submit/cancel callbacks.
  * Added support for filtering options and displaying the selected value in example flows.

* **Bug Fixes**
  * Improved boundary behavior so focus moves cleanly at list edges when wrapping is disabled, helping avoid keyboard traps.
  * Selection now remains within valid option ranges.

* **Documentation**
  * Updated the available views documentation to include the new control and its keyboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->