### PR TITLE
feat: let ANSIBackend render to a chosen file handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ try app.run()
 - **Styling** — Colors (ANSI, 256, TrueColor), bold, italic, underline, strikethrough
 - **Focus navigation** — Tab, Shift+Tab, and arrow key support out of the box
 - **Two render modes** — Fullscreen (alternate buffer) or inline (lives in scrollback)
+- **Choosable output stream** — Render to stderr so a CLI's stdout stays a machine-readable contract
 - **Cross-platform** — macOS and Linux
 - **Testable** — Built-in `TestBackend` for unit testing views without a real terminal
 
@@ -136,6 +137,18 @@ let app = Application(mode: .inline) {
 }
 
 try app.run()
+```
+
+## Rendering Somewhere Other Than stdout
+
+A CLI whose stdout is captured — `url=$(mytool publish page.html)` — cannot also paint
+frames into it. Point the backend at stderr instead; input still comes from stdin, only
+the drawing moves:
+
+```swift
+let app = Application(mode: .inline, backend: ANSIBackend(output: .standardError)) {
+    ...
+}
 ```
 
 ## Architecture

--- a/Sources/Whisker/Backend/ANSIBackend.swift
+++ b/Sources/Whisker/Backend/ANSIBackend.swift
@@ -8,8 +8,9 @@ import Darwin
 private func tcflag(_ v: Int32) -> UInt { UInt(bitPattern: Int(v)) }
 #endif
 
-/// ANSI terminal backend - writes escape sequences to stdout
+/// ANSI terminal backend - writes escape sequences to a terminal file handle
 public final class ANSIBackend: TerminalBackend, @unchecked Sendable {
+    private let output: FileHandle
     private var originalTermios: termios?
     private var outputBuffer = Data()
     private var rawModeEnabled = false
@@ -17,12 +18,24 @@ public final class ANSIBackend: TerminalBackend, @unchecked Sendable {
 
     public var renderMode: RenderMode = .fullscreen
 
-    public init() {}
+    /// Create a backend that renders to `output`.
+    ///
+    /// Defaults to stdout. Pass `.standardError` when the program's stdout is a
+    /// contract another process reads — a CLI whose output is captured with
+    /// `result=$(tool ...)` cannot also paint frames into it. Input is still read
+    /// from stdin either way; only the drawing moves.
+    public init(output: FileHandle = .standardOutput) {
+        self.output = output
+    }
 
     public var size: Size {
         var ws = winsize()
-        if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &ws) == 0 {
-            return Size(width: Int(ws.ws_col), height: Int(ws.ws_row))
+        // Ask the handle being drawn to, then stdin: when output is redirected, the
+        // terminal is still on the descriptor the keystrokes arrive on.
+        for fd in [output.fileDescriptor, STDIN_FILENO] {
+            if ioctl(fd, UInt(TIOCGWINSZ), &ws) == 0 {
+                return Size(width: Int(ws.ws_col), height: Int(ws.ws_row))
+            }
         }
         return Size(width: 80, height: 24)  // Fallback
     }
@@ -55,7 +68,7 @@ public final class ANSIBackend: TerminalBackend, @unchecked Sendable {
 
     public func flush() {
         guard !outputBuffer.isEmpty else { return }
-        FileHandle.standardOutput.write(outputBuffer)
+        output.write(outputBuffer)
         outputBuffer.removeAll(keepingCapacity: true)
     }
 

--- a/Tests/WhiskerTests/ANSIBackendTests.swift
+++ b/Tests/WhiskerTests/ANSIBackendTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import XCTest
+
+@testable import Whisker
+
+/// Where `ANSIBackend` puts its bytes.
+///
+/// The routing is the point of these tests, not the escape sequences: a program whose
+/// stdout is a contract (`result=$(tool ...)`) has to be able to render somewhere else,
+/// and a regression here is silent — the frames still appear on a terminal where both
+/// descriptors are the same device.
+final class ANSIBackendTests: XCTestCase {
+    private func drain(_ pipe: Pipe) -> String {
+        String(decoding: pipe.fileHandleForReading.availableData, as: UTF8.self)
+    }
+
+    func testWritesToTheSuppliedHandle() throws {
+        let pipe = Pipe()
+        let backend = ANSIBackend(output: pipe.fileHandleForWriting)
+
+        backend.writeRaw("hello")
+        backend.flush()
+
+        XCTAssertEqual(drain(pipe), "hello")
+    }
+
+    func testRenderCommandsGoToTheSuppliedHandle() throws {
+        let pipe = Pipe()
+        let backend = ANSIBackend(output: pipe.fileHandleForWriting)
+
+        backend.write([
+            RenderCommand(position: Position(x: 0, y: 0), cell: Cell(char: "h", style: .default))
+        ])
+        backend.flush()
+
+        XCTAssertTrue(drain(pipe).hasSuffix("h"))
+    }
+
+    func testFlushIsANoOpWhenNothingIsBuffered() throws {
+        let pipe = Pipe()
+        let backend = ANSIBackend(output: pipe.fileHandleForWriting)
+
+        backend.writeRaw("first")
+        backend.flush()
+        XCTAssertEqual(drain(pipe), "first")
+
+        // A second flush must not repeat the buffer it already emptied.
+        backend.flush()
+        backend.writeRaw("second")
+        backend.flush()
+        XCTAssertEqual(drain(pipe), "second")
+    }
+}


### PR DESCRIPTION
ANSIBackend wrote to `FileHandle.standardOutput` unconditionally, which rules Whisker out of any CLI whose stdout is a contract another process reads. The case that prompted this is `stele`, where `url=$(stele publish page.html)` is the documented way to use the tool: the URL is the whole of stdout, and a TUI painting frames into it corrupts the capture. There was no way to opt out — `TerminalBackend` is a protocol, but `ANSIBackend` is `final` with private termios and buffering logic, so the only alternative was reimplementing it.

`ANSIBackend.init(output:)` now takes the handle to draw to and defaults to `.standardOutput`, so every existing call site — including `Application`’s default `backend:` argument — is unchanged. Input still comes from stdin either way; only the drawing moves.

`size` asks the output handle first and falls back to stdin before the 80x24 default. When output is redirected the terminal is still on the descriptor the keystrokes arrive on, so querying only the output fd would silently hand back the fallback size and lay out every frame for a terminal nobody is using.

## Testing

New `ANSIBackendTests` covers the routing — raw writes and render commands land on the supplied handle, and a flush with an empty buffer does not repeat the bytes it already emitted. The routing is what regresses silently: on a terminal where stdout and stderr are the same device, a backend wired to the wrong one looks perfect.

- `swift build` — clean
- `swift test` — 126 tests, 0 failures (3 new)
- SwiftLint not installed on this machine, so the config was not run against the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rendering output can now be directed to an alternate stream, such as stderr, while input continues to come from stdin.
  * Terminal sizing remains supported when output is redirected.
* **Documentation**
  * Added guidance and an example for using an alternate rendering stream in command-line applications.
* **Tests**
  * Added coverage for redirected output, render commands, and repeated flush behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->