### PR TITLE
ci: run on every push and PR, without path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,15 @@
 name: CI
 
+# Runs on every push to main and every pull request, with no path filtering.
+# This check is required by branch protection, and a required check that a path
+# filter skips is never reported at all — which leaves the PR blocked forever,
+# with nothing the author can do to satisfy it. Paying for a few redundant runs
+# on docs-only changes is the cheaper side of that trade.
 on:
   pull_request:
-    paths:
-      - "Sources/**"
-      - "Tests/**"
-      - "Package.swift"
-      - "Package.resolved"
-      - ".swiftlint.yml"
-      - ".github/workflows/ci.yml"
   push:
     branches:
       - "main"
-    paths:
-      - "Sources/**"
-      - "Tests/**"
-      - "Package.swift"
-      - "Package.resolved"
-      - ".swiftlint.yml"
-      - ".github/workflows/ci.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Drops the path filters from the CI trigger, so the workflow runs on every push to `main` and every pull request.

This is a prerequisite for branch protection, not a change anyone wanted for its own sake. A required status check that a path filter causes to be *skipped* is never reported to GitHub at all, and GitHub cannot distinguish "skipped because the filter excluded it" from "hasn't run yet" — so the PR sits at "Expected — waiting for status to be reported" permanently, with nothing the author can do to satisfy it. The only escapes are an admin override on every docs-only PR or removing the check from the required list, which defeats the point of requiring it.

The stele repos' own trigger comment already called this out and named dropping the filters as the resolution, so this is that change.

The cost is redundant runs on documentation-only PRs. That is the cheaper half of the trade: a few wasted runner-minutes against a merge queue that can deadlock on exactly the kind of small PR that should be easiest to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jrcs1EZH6uiXusw33t3KJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run for all pull requests.
  * Updated checks to run for every push to the main branch, regardless of which files changed.
  * Added clarification about the workflow trigger configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->